### PR TITLE
Emit partcount manifest + HF-style part filenames for split releases

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -390,15 +390,33 @@ jobs:
 
         if [ "$size_mb" -gt "$MAX_SIZE" ]; then
           echo "Splitting into ${MAX_SIZE}MB parts..."
-          split -b ${MAX_SIZE}M -d --additional-suffix=.tar.gz \
+          # 1-based, 2-digit numeric suffixes -> {base}.part01.tar.gz, ...
+          split -b ${MAX_SIZE}M --numeric-suffixes=1 -a 2 \
+            --additional-suffix=.tar.gz \
             "${base}.tar.gz" "${base}.part"
           rm "${base}.tar.gz"
+
+          # Rename to HF-style partNN-of-MM.tar.gz, and emit a tiny manifest
+          # ({base}.partcount, one line with MM) so consumers can determine
+          # MM with a single HTTP GET instead of querying the GitHub Releases
+          # API (which is rate-limited to 60 req/hr per IP unauthenticated).
+          parts=( "${base}".part*.tar.gz )
+          total=${#parts[@]}
+          total_padded=$(printf "%02d" "$total")
+          for f in "${parts[@]}"; do
+            nn="${f##*.part}"; nn="${nn%%.tar.gz}"
+            mv "$f" "${base}.part${nn}-of-${total_padded}.tar.gz"
+          done
+          echo "$total" > "${base}.partcount"
+
           echo "Parts created:"
-          ls -la ${base}.part*
+          ls -la "${base}".part*
+          echo "Manifest:"
+          cat "${base}.partcount"
         fi
 
         echo "=== Release assets ==="
-        ls -la *.tar.gz 2>/dev/null || echo "No archives"
+        ls -la *.tar.gz *.partcount 2>/dev/null || echo "No archives"
 
     - name: Create Release
       env:
@@ -409,7 +427,7 @@ jobs:
         TORCH_VERSION="${{ needs.build-ubuntu.outputs.torch_version }}"
         TARGET="${{ matrix.gfx_target }}"
 
-        upload_files=$(ls -1 *.tar.gz 2>/dev/null | tr '\n' ' ')
+        upload_files=$(ls -1 *.tar.gz *.partcount 2>/dev/null | tr '\n' ' ')
         echo "Files to upload: $upload_files"
 
         # Delete existing release with same tag (idempotent rebuilds)


### PR DESCRIPTION
## Summary

When the build archive exceeds the GitHub 2 GB asset limit and is split into multiple files, also publish a tiny `{base}.partcount` text file (single line, the part count) and rename the parts to `{base}.partNN-of-MM.tar.gz`.

This lets consumers (e.g. [lemonade-sdk/lemonade](https://github.com/lemonade-sdk/lemonade)'s vLLM installer) determine the part count with a single HTTP GET on the manifest, instead of querying the GitHub Releases API. The API is rate limited to 60 req/hr per IP unauthenticated and 5000/hr with a token — both insufficient for shared CI runners and easy for a power user to exhaust. The matching lemonade-side change is in [lemonade PR #1832](https://github.com/lemonade-sdk/lemonade/pull/1832).

## What changed

- `split` switches from `-d` (0-based suffixes) to `--numeric-suffixes=1 -a 2`, so parts start at `part01` instead of `part00`
- After split, parts are renamed to `partNN-of-MM.tar.gz` and `{base}.partcount` is written
- Upload glob broadened to include `*.partcount`

Single-file releases (those that fit in one ≤1.9 GB archive) are unchanged — no manifest, same filename as before.

## Local sanity check

Tested the rename + manifest logic on a fake 10MB archive split into 3MB parts:

\`\`\`
$ ls -la
vllm0.20.1-rocm7.12.0-gfx1151-x64.part01-of-04.tar.gz
vllm0.20.1-rocm7.12.0-gfx1151-x64.part02-of-04.tar.gz
vllm0.20.1-rocm7.12.0-gfx1151-x64.part03-of-04.tar.gz
vllm0.20.1-rocm7.12.0-gfx1151-x64.part04-of-04.tar.gz
vllm0.20.1-rocm7.12.0-gfx1151-x64.partcount
$ cat *.partcount
4
\`\`\`

## Compatibility

The matching lemonade change ([#1832](https://github.com/lemonade-sdk/lemonade/pull/1832)) requires this scheme. Once lemonade lands, any client running the new code against an old (pre-rename) release will fail. So after this merges, we need to manually trigger a `workflow_dispatch` rebuild for at least gfx1151 (or all 4 targets) to publish releases in the new format **before** lemonade #1832 merges.

PR runs only validate the build — no release is created (`github.event_name != 'pull_request'` gate on the `create-release` job), so existing releases are not disturbed by this PR.

## Test plan
- [x] Local bash logic verified against fake archive
- [ ] PR build (this PR) succeeds — confirms the YAML parses and split runs
- [ ] After merge: `workflow_dispatch` rebuild for gfx1151 with `create_release=true`
- [ ] Verify on the rebuilt release page that `partcount` + `partNN-of-NN` files are present
- [ ] End-to-end: lemonade #1832 install against rebuilt release succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)