### PR TITLE
build: set PYTHONNOUSERSITE=1 in the vllm-server launcher (robustness)

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -203,6 +203,11 @@ jobs:
         export LD_LIBRARY_PATH
         export PYTHONPATH="$SP/_rocm_sdk_core/share/amd_smi:${PYTHONPATH:-}"
         export FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
+        # Ignore the user's ~/.local site-packages so the bundled, ROCm-matched
+        # torch/triton/amdsmi are always used (the bundled standalone CPython has
+        # ENABLE_USER_SITE=True, so a conflicting `pip install --user` copy would
+        # otherwise shadow the bundle's).
+        export PYTHONNOUSERSITE=1
         # Use bundled clang for Triton JIT (no system gcc needed)
         CLANG="$SP/_rocm_sdk_core/lib/llvm/bin/clang"
         [ -f "$CLANG" ] && chmod +x "$CLANG" "$CLANG"-22 2>/dev/null


### PR DESCRIPTION
Closes #14 (discussion).

## What

Add `export PYTHONNOUSERSITE=1` to the generated `vllm-server` launcher (`.github/workflows/build-vllm-rocm.yml`).

## Why

The bundle ships a relocatable python-build-standalone CPython, which has `site.ENABLE_USER_SITE = True`. So `~/.local/lib/python3.12/site-packages` is on `sys.path` ahead of the bundle's own site-packages, and a user who previously ran `pip install --user torch` / `triton` / `amdsmi` will get **that** copy loaded instead of the bundled, ROCm-matched one.

Verified on the `vllm0.22.1-rocm7.13.0-gfx1151` bundle:

| `~/.local` state | `import triton` resolves to |
|------------------|------------------------------|
| stock CUDA `triton==3.1.0` installed, launcher as-is | `~/.local` CUDA triton 3.1.0 (wrong) |
| same, with `PYTHONNOUSERSITE=1` | bundled triton 3.6.0 (ROCm 7.13) |

The launcher already sets `LD_LIBRARY_PATH`, `PYTHONPATH` (amd_smi) and `FLASH_ATTENTION_TRITON_AMD_ENABLE`; this adds the one remaining isolation knob so the bundled packages are always the ones used.

## Scope / honesty

This is a **robustness hardening**, not a verified fix for the Triton `HIP 101 invalid device ordinal` report (#3 / triton-lang/triton#10036). In my end-to-end test on the real bundle, even with the CUDA-built triton shadowing the bundle, a simple Triton kernel still ran in a spawn child **without** the HIP 101 — so I cannot attribute that crash to this and am not claiming it as the fix. It is a sensible isolation improvement on its own; #14 has the full investigation.

Opening as a **draft** for maintainer input (the right place for this may be the launcher heredoc here, or documenting the `~/.local` interaction). I have not run the full CI build/qualification.

AI usage disclosure: this change was prepared with AI assistance; a human reviewed and verified it and can explain every line. Verified: import-resolution behavior checked on the real bundle; one-line change.

