### PR TITLE
build: keep the actual clang-<major> when trimming LLVM (clang-23 was deleted)

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -245,15 +245,21 @@ jobs:
 
         # Trim LLVM toolchain: keep only clang + its libs (~350MB saved)
         LLVM="$SP/_rocm_sdk_core/lib/llvm"
-        # Keep only clang, clang-22, remove everything else from bin/
-        find "$LLVM/bin" -type f ! -name "clang" ! -name "clang-22" -delete 2>/dev/null || true
+        # The `clang` driver re-execs the versioned `clang-<major>` binary, so we
+        # must keep whichever major this LLVM actually is. Derive it instead of
+        # hardcoding (the resource dir lib/clang/<major> is the source of truth);
+        # fall back to `clang -dumpversion`.
+        CLANG_MAJOR="$(ls "$LLVM/lib/clang" 2>/dev/null | grep -E "^[0-9]+$" | sort -n | tail -1)"
+        [ -z "$CLANG_MAJOR" ] && CLANG_MAJOR="$("$LLVM/bin/clang" -dumpversion 2>/dev/null | cut -d. -f1)"
+        # Keep only clang + clang-<major>, remove everything else from bin/
+        find "$LLVM/bin" -type f ! -name "clang" ! -name "clang-${CLANG_MAJOR}" -delete 2>/dev/null || true
         find "$LLVM/bin" -type l ! -name "clang" -delete 2>/dev/null || true
         # Keep only libs that clang needs (libclang-cpp, libLLVM, rocm_sysdeps)
         find "$LLVM/lib" -name "*.so*" \
           ! -name "libclang-cpp*" \
           ! -name "libLLVM*" \
           -delete 2>/dev/null || true
-        rm -rf "$LLVM/lib/clang/22/include/cuda_wrappers" 2>/dev/null || true
+        rm -rf "$LLVM/lib/clang/${CLANG_MAJOR}/include/cuda_wrappers" 2>/dev/null || true
 
         # Trim ROCm SDK bin/ (Python wrapper scripts, not needed)
         rm -rf "$SP/_rocm_sdk_core/bin" 2>/dev/null || true


### PR DESCRIPTION
Fixes #16.

## What

The "Trim LLVM toolchain" step kept only `clang` and a **hardcoded `clang-22`**, but the bundled LLVM is major **23**. The `clang` driver re-execs `clang-23`, which the keep-list didn't match — so `clang-23` was deleted. The shipped bundle has the `clang` driver but no `clang-23`, and Triton's JIT fails with `could not exec .../clang-23`.

## Change

Derive the LLVM major from the resource dir `lib/clang/<major>` (fallback `clang -dumpversion`) and keep `clang-${major}` + its `cuda_wrappers` path, instead of hardcoding `22`. Stays correct across LLVM bumps.

```diff
-        # Keep only clang, clang-22, remove everything else from bin/
-        find "$LLVM/bin" -type f ! -name "clang" ! -name "clang-22" -delete
+        CLANG_MAJOR="$(ls "$LLVM/lib/clang" | grep -E '^[0-9]+$' | sort -n | tail -1)"
+        [ -z "$CLANG_MAJOR" ] && CLANG_MAJOR="$("$LLVM/bin/clang" -dumpversion | cut -d. -f1)"
+        find "$LLVM/bin" -type f ! -name "clang" ! -name "clang-${CLANG_MAJOR}" -delete
...
-        rm -rf "$LLVM/lib/clang/22/include/cuda_wrappers"
+        rm -rf "$LLVM/lib/clang/${CLANG_MAJOR}/include/cuda_wrappers"
```

## Evidence

On the released `vllm0.22.1-rocm7.13.0-gfx1151` bundle: `bin/clang-23` is absent (only the 26 KB `clang` driver), `lib/clang/23/` + `libclang-cpp.so.23` are present, and `clang --version` errors with `could not exec .../clang-23`. Triton JIT then fails; supplying a system clang lets it compile.

## Verification (honest)

I did **not** re-run the full build CI myself. This repo's `pull_request` build + the gfx1151 qualification (tier2 inference uses Triton) are the right place to confirm the rebuilt bundle keeps `clang-23` and that Triton-based inference passes. Opening as **draft** for that reason and for maintainer review of the approach.

AI usage disclosure: this change was prepared with AI assistance; a human reviewed and verified it and can explain every line. Verified: missing-binary + JIT failure reproduced on the released bundle.

