### PR TITLE
fix: LD_PRELOAD NVML stub to suppress CUDA detection on hybrid AMD+NVIDIA systems

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -449,6 +449,20 @@ jobs:
         sed -i 's|mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|_pso = os.path.join(dirname, "hip_utils_prebuilt.so")\n        if os.path.exists(_pso):\n            import importlib.util as _ilu\n            _sp = _ilu.spec_from_file_location("hip_utils", _pso)\n            mod = _ilu.module_from_spec(_sp)\n            _sp.loader.exec_module(mod)\n        else:\n            mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|' "$DRIVER_PY"
         $VLLM_ROOT/bin/python3 -c "import ast; ast.parse(open('$DRIVER_PY').read()); print('Patched driver.py — syntax OK')"
 
+    - name: Build NVML stub (hides NVIDIA GPUs on hybrid AMD+NVIDIA systems)
+      run: |
+        # Compile a tiny LD_PRELOAD stub that intercepts NVML init and
+        # device enumeration. When preloaded, pynvml sees zero NVIDIA GPUs
+        # and vLLM's CUDA platform plugin stays inactive, while the ROCm
+        # platform activates normally through HIP/ROCm libraries.
+        STUB_SRC="$GITHUB_WORKSPACE/scripts/nvml-stub/nvml_stub.c"
+        STUB_SO="$VLLM_ROOT/lib/nvml_stub.so"
+        mkdir -p "$VLLM_ROOT/lib"
+        gcc -shared -fPIC -O2 -o "$STUB_SO" "$STUB_SRC"
+        echo "NVML stub compiled: $STUB_SO ($(stat -c%s "$STUB_SO") bytes)"
+        # Smoke: verify symbols
+        nm -D "$STUB_SO" | grep nvml || true
+
     - name: Create launcher script
       run: |
         cat > $VLLM_ROOT/bin/vllm-server << 'LAUNCHER_EOF'
@@ -471,6 +485,17 @@ jobs:
         CLANG="$SP/_rocm_sdk_core/lib/llvm/bin/clang"
         [ -f "$CLANG" ] && chmod +x "$CLANG" "$CLANG"-* 2>/dev/null
         export CC="$CLANG"
+        # On hybrid AMD+NVIDIA laptops, vLLM's platform detection finds both
+        # CUDA (pynvml sees the dGPU) and ROCm and raises RuntimeError:
+        # "Only one platform plugin can be activated". Preload the NVML stub
+        # so pynvml sees zero NVIDIA GPUs and the CUDA platform stays inactive,
+        # while ROCm probes through HIP/ROCm libs normally.
+        if [ "${VLLM_TARGET_DEVICE:-}" = "rocm" ]; then
+            NVML_STUB="$VENV_DIR/lib/nvml_stub.so"
+            if [ -f "$NVML_STUB" ]; then
+                export LD_PRELOAD="$NVML_STUB${LD_PRELOAD:+:$LD_PRELOAD}"
+            fi
+        fi
         exec "$SCRIPT_DIR/python3" -m vllm.entrypoints.openai.api_server "$@"
         LAUNCHER_EOF
 

--- a/scripts/nvml-stub/nvml_stub.c
+++ b/scripts/nvml-stub/nvml_stub.c
@@ -1,0 +1,28 @@
+// nvml_stub.c — LD_PRELOAD stub that hides NVIDIA GPUs from NVML.
+//
+// When preloaded, nvmlInit returns an error and nvmlDeviceGetCount returns 0,
+// which prevents vLLM's CUDA platform plugin from activating on hybrid
+// AMD+NVIDIA systems while leaving ROCm device probing untouched.
+//
+// NVML C API: https://docs.nvidia.com/deploy/nvml-api/
+
+#define NVML_ERROR_UNINITIALIZED 1
+
+int nvmlInit(void) {
+    return NVML_ERROR_UNINITIALIZED;
+}
+
+int nvmlInit_v2(void) {
+    return NVML_ERROR_UNINITIALIZED;
+}
+
+int nvmlInitWithFlags(unsigned int flags) {
+    (void)flags;
+    return NVML_ERROR_UNINITIALIZED;
+}
+
+int nvmlDeviceGetCount(unsigned int *deviceCount) {
+    if (deviceCount)
+        *deviceCount = 0;
+    return NVML_ERROR_UNINITIALIZED;
+}


### PR DESCRIPTION
## Problem

On laptops with both AMD iGPU and NVIDIA dGPU, vLLM's platform detection finds both CUDA (pynvml sees the dGPU via NVML) and ROCm and raises:

```
RuntimeError: Only one platform plugin can be activated, but got: ['cuda', 'rocm']
```

## Why env var approaches don't work

- **`CUDA_VISIBLE_DEVICES=""`** — NVML bypasses the CUDA runtime. It talks directly to the NVIDIA kernel driver via `libnvidia-ml.so`, so `CUDA_VISIBLE_DEVICES` has no effect on `nvmlDeviceGetCount()`.
- **`CUDA_VISIBLE_DEVICES="" + HIP_VISIBLE_DEVICES=0`** — Same problem; NVML doesn't respect either variable.
- **Python monkey-patching** — Fragile to vLLM internal API changes (function renames, module restructures).

## Solution: LD_PRELOAD NVML stub

A 25-line C file compiled to a shared library. When `LD_PRELOAD`ed, it intercepts:

| NVML function | Stub behavior |
|---------------|---------------|
| `nvmlInit()` | Returns error |
| `nvmlInit_v2()` | Returns error |
| `nvmlInitWithFlags()` | Returns error |
| `nvmlDeviceGetCount()` | Returns 0 devices |

This makes pynvml see zero NVIDIA GPUs, so the CUDA platform plugin never activates — while ROCm probes through HIP/ROCm libraries normally.

### Why this is robust

- **Does not modify upstream wheel contents** — respects the repo's inviolable principles
- **NVML C ABI is stable** — these function signatures haven't changed in years
- **Works at the dynamic linker level** — can't be bypassed by any Python code path
- **Minimal** — 25 lines of C, one `gcc -shared` invocation

## How it works end-to-end

1. **Lemonade** sets `VLLM_TARGET_DEVICE=rocm` in the vLLM subprocess environment ([PR #2459](https://github.com/lemonade-sdk/lemonade/pull/2459))
2. **Launcher** detects `VLLM_TARGET_DEVICE=rocm` → `LD_PRELOAD`s the stub
3. **vLLM starts** → pynvml sees zero NVIDIA GPUs → CUDA platform inactive → ROCm activates ✓

## Companion PR

- lemonade: https://github.com/lemonade-sdk/lemonade/pull/2459

🤖 Generated with [Claude Code](https://claude.com/claude-code)