### PR TITLE
feat: vLLM-Omni bundle variant + omni qualification + daily auto-build

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -39,9 +39,19 @@ on:
     # Daily: poll for a new nightly. The detect-nightly job dedups against the
     # qualification feed, so days with no new wheel cost only the cheap poll.
     - cron: '0 15 * * *'
+    # Daily omni auto-build (gfx1151 only). Distinguished from the plain nightly
+    # by github.event.schedule below; builds vLLM-Omni on the current nightly
+    # base, qualifies it (tier2_omni), and publishes the vllm-omni* release on
+    # green. Offset 90 min so it queues behind the plain nightly on the shared
+    # single-GPU dev_lab runner. NOTE: omni is not deduped like plain nightly —
+    # it rebuilds daily even if the base is unchanged (cheap relative to value;
+    # add an omni-specific dedup later if runner time becomes a concern).
+    - cron: '30 16 * * *'
 
 env:
-  GFX_TARGETS: ${{ github.event.inputs.gfx_target || 'gfx110X,gfx1151,gfx1150,gfx120X' }}
+  # Omni auto-build cron targets gfx1151 only (the qualified, hardware-validated
+  # target); plain nightly + dispatch keep the full target set.
+  GFX_TARGETS: ${{ github.event.inputs.gfx_target || (github.event.schedule == '30 16 * * *' && 'gfx1151') || 'gfx110X,gfx1151,gfx1150,gfx120X' }}
   # Channel is a run-level parameter (not a matrix axis): stable and nightly
   # have different triggers and different upstream sources, so they run as
   # separate workflow runs. Scheduled runs default to nightly.
@@ -50,7 +60,7 @@ env:
   # channel) and release it as a separate vllm-omni* artifact. vLLM-Omni is a
   # pure-Python layer; the omni bundle is the base bundle + vllm-omni + its deps
   # (see scripts/build_omni_layer.sh). Off for normal nightly/stable runs.
-  OMNI: ${{ github.event.inputs.omni || 'false' }}
+  OMNI: ${{ github.event.inputs.omni || (github.event.schedule == '30 16 * * *') || 'false' }}
 
 jobs:
   # Decide whether AMD has published a nightly vLLM wheel we have not already
@@ -144,7 +154,7 @@ jobs:
     # up (and qualify/create-release already skip PRs). Runs on dispatch + cron.
     # Omni builds are explicit manual dispatches — build regardless of the
     # nightly dedup (which would skip an already-qualified base).
-    if: (needs.detect-nightly.outputs.is_new == 'true' || github.event.inputs.omni == 'true') && github.event_name != 'pull_request'
+    if: (needs.detect-nightly.outputs.is_new == 'true' || github.event.inputs.omni == 'true' || github.event.schedule == '30 16 * * *') && github.event_name != 'pull_request'
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.ubuntu_matrix)}}
       fail-fast: false

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -658,16 +658,22 @@ jobs:
       labels: [self-hosted, Linux]
     env:
       GFX: gfx1151
-    # Only on release builds. Skips PRs, dispatches with create_release=false,
-    # and dispatches that didn't select gfx1151 (nothing to test → release ungated).
+    # Runs on release builds AND on omni dispatches (omni is experimental —
+    # always qualify it, even as a no-publish dry run; release stays gated on
+    # create_release in the create-release job). Skips PRs and dispatches that
+    # didn't select gfx1151 (nothing to test → release ungated).
     if: >-
       github.event_name != 'pull_request' &&
       (
         github.event_name == 'schedule' ||
         (
           github.event_name == 'workflow_dispatch' &&
-          (github.event.inputs.create_release == 'true' || github.event.inputs.create_release == null) &&
-          contains(github.event.inputs.gfx_target, 'gfx1151')
+          contains(github.event.inputs.gfx_target, 'gfx1151') &&
+          (
+            github.event.inputs.create_release == 'true' ||
+            github.event.inputs.create_release == null ||
+            github.event.inputs.omni == 'true'
+          )
         )
       )
     steps:

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -26,6 +26,11 @@ on:
         description: 'Stable channel: vLLM version to install (cp313 wheel at rocm.frameworks.amd.com/whl/gfx1151/vllm/)'
         required: false
         default: '0.19.1.dev3+rocm7.13.0.g72ed2b398.d20260513'
+      omni:
+        description: 'Also layer vLLM-Omni onto the bundle and release it as a separate vllm-omni* artifact (implies a build regardless of nightly dedup)'
+        required: false
+        default: false
+        type: boolean
 
   pull_request:
     types: [opened, synchronize, reopened]
@@ -41,6 +46,11 @@ env:
   # have different triggers and different upstream sources, so they run as
   # separate workflow runs. Scheduled runs default to nightly.
   CHANNEL: ${{ github.event.inputs.channel || 'nightly' }}
+  # When true, layer vLLM-Omni on top of the base bundle (built on the same
+  # channel) and release it as a separate vllm-omni* artifact. vLLM-Omni is a
+  # pure-Python layer; the omni bundle is the base bundle + vllm-omni + its deps
+  # (see scripts/build_omni_layer.sh). Off for normal nightly/stable runs.
+  OMNI: ${{ github.event.inputs.omni || 'false' }}
 
 jobs:
   # Decide whether AMD has published a nightly vLLM wheel we have not already
@@ -132,13 +142,17 @@ jobs:
     # Also skip on pull_request: this is a heavy multi-target repackage that now
     # runs on the shared dev_lab GPU pool, so PR pushes must not tie those boxes
     # up (and qualify/create-release already skip PRs). Runs on dispatch + cron.
-    if: needs.detect-nightly.outputs.is_new == 'true' && github.event_name != 'pull_request'
+    # Omni builds are explicit manual dispatches — build regardless of the
+    # nightly dedup (which would skip an already-qualified base).
+    if: (needs.detect-nightly.outputs.is_new == 'true' || github.event.inputs.omni == 'true') && github.event_name != 'pull_request'
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.ubuntu_matrix)}}
       fail-fast: false
     outputs:
       vllm_version: ${{ steps.set-outputs.outputs.vllm_version }}
       torch_version: ${{ steps.set-outputs.outputs.torch_version }}
+      # Non-empty only on omni builds; create-release uses it to pick the tag.
+      omni_version: ${{ steps.set-outputs.outputs.omni_version }}
 
     steps:
     - name: Checkout repository
@@ -546,6 +560,19 @@ jobs:
         echo "Top consumers:"
         du -sh $SP/torch/ $SP/vllm/ $SP/_rocm_sdk_core/ $SP/aiter/ $SP/triton/ 2>/dev/null || true
 
+    - name: Layer vLLM-Omni onto the bundle (omni builds only)
+      # MUST run AFTER the Strip step: Strip deletes opencv/onnx/peft/timm (and
+      # pip) — exactly the deps the omni layer reinstalls. build_omni_layer.sh
+      # re-bootstraps pip and pulls vllm-omni + its runtime/multimodal deps + an
+      # ABI-matched torchaudio. torchaudio must come from the SAME ROCm index as
+      # the bundled torch: per-gfx stable index on the stable channel, AMD's
+      # multi-arch nightly index on nightly.
+      if: ${{ env.OMNI == 'true' }}
+      env:
+        TORCH_INDEX: ${{ env.CHANNEL == 'stable' && steps.wheel-urls.outputs.torch_index || 'https://rocm.nightlies.amd.com/whl-multi-arch' }}
+      run: |
+        bash scripts/build_omni_layer.sh
+
     - name: Verify bundled environment works
       run: |
         SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
@@ -605,6 +632,11 @@ jobs:
         torch_ver=$($VLLM_ROOT/bin/python3 -c "import torch; print(torch.__version__)")
         echo "vllm_version=$vllm_ver" >> $GITHUB_OUTPUT
         echo "torch_version=$torch_ver" >> $GITHUB_OUTPUT
+        # Empty on non-omni builds. Read from dist-info (no heavy import) so the
+        # create-release tag can distinguish vllm-omni* artifacts.
+        omni_ver=$(ls -d "$SP"/vllm_omni-*.dist-info 2>/dev/null | head -1 \
+          | sed -E 's#.*/vllm_omni-(.*)\.dist-info#\1#')
+        echo "omni_version=$omni_ver" >> $GITHUB_OUTPUT
 
     - name: Clean up
       if: always()
@@ -727,6 +759,10 @@ jobs:
         FRAG="$WORK/fragments"; mkdir -p "$FRAG"
         Q="$GITHUB_WORKSPACE/scripts/qualify"
         TAG="vllm${{ needs.build-ubuntu.outputs.vllm_version }}-${GFX}"
+        # Omni builds qualify the omni serving path and record an omni candidate tag.
+        if [ "$OMNI" = "true" ]; then
+          TAG="vllm-omni${{ needs.build-ubuntu.outputs.omni_version }}-${GFX}"
+        fi
 
         # The tiers are run WITHOUT --fail-on-error so all 16 tests execute and
         # emit a JSON fragment even when one fails; `aggregate --fail-on-no-promote`
@@ -741,12 +777,24 @@ jobs:
             --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier1-report.json" || true
         echo "::endgroup::"
 
-        echo "::group::Tier 2 — functional inference (T2.1–T2.5)"
-        "$PY" "$Q/tier2_inference.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
-            --channel "$CHANNEL" --candidate-tag "$TAG" \
-            --model Qwen/Qwen2.5-0.5B-Instruct --logs-dir "$FRAG" \
-            --output "$FRAG/tier2-report.json" || true
-        echo "::endgroup::"
+        # Tier 2 functional inference. Omni bundles run the omni serving path
+        # (vllm-omni-server + single-GPU deploy config) instead of plain vLLM;
+        # both emit a `tier2` fragment so the aggregate require-tiers rule is
+        # identical. The two are mutually exclusive per run.
+        if [ "$OMNI" = "true" ]; then
+          echo "::group::Tier 2 (omni) — functional inference via vllm-omni-server"
+          "$PY" "$Q/tier2_omni.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
+              --channel "$CHANNEL" --candidate-tag "$TAG" --logs-dir "$FRAG" \
+              --output "$FRAG/tier2-report.json" || true
+          echo "::endgroup::"
+        else
+          echo "::group::Tier 2 — functional inference (T2.1–T2.5)"
+          "$PY" "$Q/tier2_inference.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
+              --channel "$CHANNEL" --candidate-tag "$TAG" \
+              --model Qwen/Qwen2.5-0.5B-Instruct --logs-dir "$FRAG" \
+              --output "$FRAG/tier2-report.json" || true
+          echo "::endgroup::"
+        fi
 
         echo "=== Aggregate fragments → qualification report (gates the job) ==="
         "$PY" "$Q/aggregate.py" --fragments-dir "$FRAG" --gfx-target "$GFX" \
@@ -898,14 +946,22 @@ jobs:
       run: |
         VLLM_VERSION="${{ needs.build-ubuntu.outputs.vllm_version }}"
         TORCH_VERSION="${{ needs.build-ubuntu.outputs.torch_version }}"
+        OMNI_VERSION="${{ needs.build-ubuntu.outputs.omni_version }}"
         TARGET="${{ matrix.gfx_target }}"
 
         # Extract ROCm version from torch version string
         ROCM_VERSION=$(echo "$TORCH_VERSION" | grep -oP 'rocm[\d.]+' || echo "rocm")
 
-        # Tag format: vllm{version}-{rocm_version}-{gfx_target}
-        # e.g. vllm0.19.0-rocm7.12.0-gfx1150
-        TAG="vllm${VLLM_VERSION}-${ROCM_VERSION}-${TARGET}"
+        # Omni builds release as a SEPARATE artifact, tagged by the vllm-omni
+        # version so it never collides with the plain-vLLM bundle:
+        #   vllm-omni{omni_ver}-{rocm_version}-{gfx_target}
+        # Plain builds keep the existing scheme:
+        #   vllm{version}-{rocm_version}-{gfx_target}  e.g. vllm0.19.0-rocm7.12.0-gfx1150
+        if [ -n "$OMNI_VERSION" ]; then
+          TAG="vllm-omni${OMNI_VERSION}-${ROCM_VERSION}-${TARGET}"
+        else
+          TAG="vllm${VLLM_VERSION}-${ROCM_VERSION}-${TARGET}"
+        fi
         echo "tag=${TAG}" >> $GITHUB_OUTPUT
         echo "Generated release tag: ${TAG}"
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ Our GitHub Actions workflow:
 
 > **Linux (gfx1150/APU):** OOM despite free VRAM? Add `ttm.pages_limit=12582912` (48 GB) to the kernel cmdline (e.g. GRUB), run `update-grub`, then reboot. See [TheRock FAQ](https://github.com/ROCm/TheRock/blob/main/docs/faq.md#gfx1151-strix-halo-specific-questions).
 
+### vLLM-Omni variant (experimental)
+
+[vLLM-Omni](https://github.com/vllm-project/vllm-omni) serves omni / any-to-any
+multimodal models (Qwen-Omni, Cosmos3, …). It is a **pure-Python layer** on top
+of the same base vLLM + PyTorch + Triton this repo already bundles, so the omni
+build is the base bundle plus `vllm-omni`, its runtime deps, an ABI-matched
+`torchaudio`, and a `bin/vllm-omni-server` launcher — see
+[`scripts/build_omni_layer.sh`](scripts/build_omni_layer.sh).
+
+It ships as a **separate release artifact** (tag `vllm-omni<ver>-rocm<ver>-<gfx>`),
+not folded into the lean LLM bundle — omni pulls ~1 GB of extra deps that
+plain-LLM users should not carry. Trigger it from the **Build vLLM + ROCm**
+workflow with the `omni: true` dispatch input (`vllm-omni`'s version is
+auto-matched to the base vLLM major.minor). Run a serving model with
+`bin/vllm-omni-server serve <model> --omni --deploy-config <single-gpu.yaml>`;
+on a single-GPU box you must supply a deploy config that colocates all stages on
+device 0 (the upstream defaults target multi-GPU hosts).
+
 ## Dependencies
 
 ### Runtime (bundled in the release)

--- a/README.md
+++ b/README.md
@@ -110,9 +110,12 @@ build is the base bundle plus `vllm-omni`, its runtime deps, an ABI-matched
 
 It ships as a **separate release artifact** (tag `vllm-omni<ver>-rocm<ver>-<gfx>`),
 not folded into the lean LLM bundle — omni pulls ~1 GB of extra deps that
-plain-LLM users should not carry. Trigger it from the **Build vLLM + ROCm**
-workflow with the `omni: true` dispatch input (`vllm-omni`'s version is
-auto-matched to the base vLLM major.minor). Run a serving model with
+plain-LLM users should not carry. It **auto-builds daily** for gfx1151 (a second
+`schedule` cron at 16:30 UTC) — builds on the current nightly base, qualifies
+via `tier2_omni`, and publishes the `vllm-omni*` release on green — and can also
+be built on demand from the **Build vLLM + ROCm** workflow with the `omni: true`
+dispatch input (`vllm-omni`'s version is auto-matched to the base vLLM
+major.minor). Run a serving model with
 `bin/vllm-omni-server serve <model> --omni --deploy-config <single-gpu.yaml>`;
 on a single-GPU box you must supply a deploy config that colocates all stages on
 device 0 (the upstream defaults target multi-GPU hosts).

--- a/scripts/build_omni_layer.sh
+++ b/scripts/build_omni_layer.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# build_omni_layer.sh — turn a built plain-vLLM ROCm bundle into a vLLM-Omni bundle.
+#
+# vLLM-Omni is a pure-Python layer (one py3-none-any wheel) that rides on the
+# base vLLM + torch + Triton already in the bundle, so the omni artifact is the
+# SAME relocatable bundle plus: vllm-omni, its pure-Python runtime deps, an
+# ABI-matched torchaudio, the multimodal deps the base trim drops
+# (timm / opencv / peft), and a dedicated `vllm-omni-server` launcher.
+#
+# This is intentionally a thin layer invoked AFTER the base "Install vLLM +
+# PyTorch" step in build-vllm-rocm.yml — it does not rebuild the base. Keeping
+# the lean LLM bundle and the heavier omni bundle as separate release artifacts
+# is deliberate (see README): omni pulls ~1GB of deps and pins Python <3.14
+# that plain-LLM users should not carry.
+#
+# Required env (exported by the workflow's earlier steps):
+#   VLLM_ROOT   — bundle root (contains bin/, lib/python3.X/site-packages)
+#   TORCH_INDEX — the same ROCm torch index the base install used (for a
+#                 torchaudio built against the bundled torch's ABI)
+# Optional env:
+#   VLLM_OMNI_VER — vllm-omni version to install. Default: auto-match the base
+#                   vLLM major.minor (vllm-omni REQUIRES the same major.minor,
+#                   or its import-time patch layer misbehaves).
+#
+# Note on fa3-fwd: it is a declared vllm-omni dependency (flash-attn-3 forward,
+# used only by the diffusion-attention path for Cosmos3 / image+video models).
+# It installs cleanly here — it ships a cp39-abi3 manylinux x86_64 wheel, so it
+# is NOT cp314-blocked — but whether its kernels run on ROCm is unverified; AR
+# omni models (Qwen-Omni) never invoke it.
+set -euo pipefail
+
+: "${VLLM_ROOT:?VLLM_ROOT must point at the built bundle}"
+PYBIN="$(ls "$VLLM_ROOT"/bin/python3.1? | head -1)"
+SP="$(echo "$VLLM_ROOT"/lib/python3.*/site-packages)"
+export PYTHONNOUSERSITE=1
+
+echo "== omni layer: bundle=$VLLM_ROOT python=$("$PYBIN" --version)"
+
+# --- pip is trimmed from the bundle; bootstrap if absent --------------------
+if ! "$PYBIN" -m pip --version >/dev/null 2>&1; then
+  echo "== bootstrapping pip (trimmed from base bundle)"
+  curl -fsSL -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+  "$PYBIN" /tmp/get-pip.py
+fi
+
+# --- resolve versions --------------------------------------------------------
+BASE_VLLM="$("$PYBIN" -c 'import importlib.metadata as m; print(m.version("vllm"))')"
+BASE_MM="$(echo "$BASE_VLLM" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')"          # e.g. 0.23
+TORCH_VER="$("$PYBIN" -c 'import importlib.metadata as m; print(m.version("torch"))')"
+: "${VLLM_OMNI_VER:=$("$PYBIN" - <<PY
+import json,urllib.request
+base="${BASE_MM}"
+d=json.load(urllib.request.urlopen("https://pypi.org/pypi/vllm-omni/json"))
+# newest release whose major.minor == base vLLM major.minor (incl. rc)
+cands=[v for v in d["releases"] if v.split("rc")[0].rsplit(".",1)[0]==base]
+print(sorted(cands)[-1] if cands else "")
+PY
+)}"
+[ -n "$VLLM_OMNI_VER" ] || { echo "::error::no vllm-omni release matches base vLLM $BASE_MM"; exit 1; }
+echo "== base vLLM=$BASE_VLLM (mm=$BASE_MM) torch=$TORCH_VER -> vllm-omni==$VLLM_OMNI_VER"
+
+# Protect the GPU-coupled stack so dep resolution can never swap the ROCm
+# torch/vllm/triton/transformers for a PyPI build. safetensors/accelerate are
+# left to float (diffusers 0.38 needs safetensors>=0.8).
+CONSTRAINTS=/tmp/omni-constraints.txt
+"$PYBIN" - > "$CONSTRAINTS" <<'PY'
+import importlib.metadata as m
+for p in ("torch","vllm","pytorch-triton-rocm","triton","torchvision","torchaudio","transformers","numpy"):
+    try: print(f"{p}=={m.version(p)}")
+    except Exception: pass
+PY
+
+# --- ABI-matched torchaudio (omni api_server imports it eagerly) ------------
+# Not in the base bundle. Pull the build that matches the bundled torch
+# version+stamp from the same ROCm index the base used.
+if ! "$PYBIN" -c 'import torchaudio' >/dev/null 2>&1; then
+  echo "== installing torchaudio==$TORCH_VER from $TORCH_INDEX"
+  "$PYBIN" -m pip install -c "$CONSTRAINTS" \
+    --index-url "${TORCH_INDEX:?set TORCH_INDEX to the base torch ROCm index}" \
+    --extra-index-url https://pypi.org/simple/ \
+    "torchaudio==$TORCH_VER"
+fi
+
+# --- vllm-omni + runtime deps ------------------------------------------------
+# --ignore-requires-python: every vllm-omni release pins Python <3.14, but the
+# qualified nightly base is cp314. The cap is conservative — validated to run on
+# 3.14 — and this is a bundle we control + qualify, so we override it here. (The
+# base install already uses --ignore-requires-python for amd-quark's cp<3.13 cap.)
+OMNI_DEPS=(
+  aenum omegaconf "diffusers==0.38.0" "cache-dit==1.3.0" x-transformers torchsde
+  janus prettytable av soundfile einops "openai-whisper" onnxruntime "imageio[ffmpeg]"
+  # multimodal deps the base bundle trims but omni model loading needs:
+  timm opencv-python-headless peft
+)
+# vllm-omni's own Requires-Dist (incl. fa3-fwd) is pulled by naming it as a
+# top-level requirement below; OMNI_DEPS only adds the multimodal extras the
+# base trim drops plus exact-pinned deps for resolver stability.
+
+echo "== installing vllm-omni==$VLLM_OMNI_VER + ${#OMNI_DEPS[@]} deps"
+"$PYBIN" -m pip install --ignore-requires-python -c "$CONSTRAINTS" \
+  "vllm-omni==$VLLM_OMNI_VER" "${OMNI_DEPS[@]}"
+
+# --- omni launcher -----------------------------------------------------------
+# Mirrors bin/vllm-server's env (LD_LIBRARY_PATH/PYTHONPATH/clang) but execs the
+# vllm-omni CLI. The bundled bin/vllm has a hardcoded #!/opt/vllm shebang that
+# breaks under relocation, so we always go through `python3 -m`.
+cat > "$VLLM_ROOT/bin/vllm-omni-server" <<'LAUNCHER_EOF'
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$(dirname "$SCRIPT_DIR")"
+SP="$(echo "$VENV_DIR"/lib/python3.*/site-packages)"
+for libdir in "$SP"/_rocm_sdk_*/lib "$SP"/torch/lib; do
+  [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+done
+LD_LIBRARY_PATH="$SP/_rocm_sdk_core/lib/llvm/lib:${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH
+export PYTHONPATH="$SP/_rocm_sdk_core/share/amd_smi:${PYTHONPATH:-}"
+export FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
+CLANG="$SP/_rocm_sdk_core/lib/llvm/bin/clang"
+[ -f "$CLANG" ] && chmod +x "$CLANG" "$CLANG"-* 2>/dev/null
+export CC="$CLANG"
+exec "$SCRIPT_DIR/python3" -m vllm_omni.entrypoints.cli.main "$@"
+LAUNCHER_EOF
+chmod +x "$VLLM_ROOT/bin/vllm-omni-server"
+
+# --- verify the layer imports under the launcher env ------------------------
+echo "== verifying vllm_omni import"
+LD_LIBRARY_PATH="$SP/_rocm_sdk_core/lib/llvm/lib" \
+PYTHONPATH="$SP/_rocm_sdk_core/share/amd_smi" \
+  "$VLLM_ROOT/bin/vllm-omni-server" --help >/dev/null 2>&1 \
+  || { echo "::error::vllm-omni-server failed to import"; exit 1; }
+
+echo "== omni layer complete: vllm-omni==$VLLM_OMNI_VER on vLLM $BASE_VLLM"

--- a/scripts/build_omni_layer.sh
+++ b/scripts/build_omni_layer.sh
@@ -100,6 +100,12 @@ echo "== installing vllm-omni==$VLLM_OMNI_VER + ${#OMNI_DEPS[@]} deps"
 "$PYBIN" -m pip install --ignore-requires-python -c "$CONSTRAINTS" \
   "vllm-omni==$VLLM_OMNI_VER" "${OMNI_DEPS[@]}"
 
+# --- re-strip pip (we bootstrapped it above) to match the base bundle --------
+# The base Strip step removes pip; we re-added it only to install this layer.
+# Remove it again so the omni bundle stays lean and passes qualification T0.4
+# (which flags an SP/pip dir as bundle bloat). Deps are installed; pip is done.
+rm -rf "$SP"/pip "$SP"/pip-*.dist-info "$SP"/wheel "$SP"/wheel-*.dist-info 2>/dev/null || true
+
 # --- omni launcher -----------------------------------------------------------
 # Mirrors bin/vllm-server's env (LD_LIBRARY_PATH/PYTHONPATH/clang) but execs the
 # vllm-omni CLI. The bundled bin/vllm has a hardcoded #!/opt/vllm shebang that

--- a/scripts/qualify/README.md
+++ b/scripts/qualify/README.md
@@ -47,6 +47,12 @@ suffix (`…-stable` / `…-nightly`), **not** GitHub's single "latest" pointer
   amdsmi ASIC read (warn). **T1.5** `vllm-server --help`.
 - **T2.1** server boots. **T2.2** non-empty completion. **T2.3** greedy
   determinism. **T2.4** chat. **T2.5** streaming.
+- **Omni variant** (`tier2_omni.py`, run *instead of* `tier2_inference.py` on
+  builds made with the workflow's `omni: true` input): boots `vllm-omni-server`
+  on `Qwen2.5-Omni-3B` with a single-GPU deploy config
+  (`deploy/qwen2_5_omni_1gpu.yaml`) and checks **T2.1** omni server boot,
+  **T2.2** chat completion, **T2.3** streaming. Emits the same `tier2` fragment,
+  so promotion (`--require-tiers tier0,tier1,tier2`) is unchanged.
 - **T3.n** lemonade installs the candidate and each hot vLLM model loads + chats;
   tokens/sec and TTFT captured as metrics.
 

--- a/scripts/qualify/deploy/qwen2_5_omni_1gpu.yaml
+++ b/scripts/qualify/deploy/qwen2_5_omni_1gpu.yaml
@@ -1,0 +1,61 @@
+# Single-GPU deploy config for Qwen2.5-Omni, used by tier2_omni.py qualification.
+#
+# vLLM-Omni's upstream default (vllm_omni/deploy/qwen2_5_omni.yaml) is "verified
+# on 2x H100" and places the talker stage on cuda:1. On a single-GPU box that
+# stage's engine core gets CUDA_VISIBLE_DEVICES=1 -> 0 visible devices and dies
+# with "DP adjusted local rank out of bounds". This override colocates all three
+# stages (thinker / talker / code2wav) on device 0 with rebalanced
+# gpu_memory_utilization summing < 1.0.
+async_chunk: false
+
+stages:
+  - stage_id: 0          # thinker (AR LLM)
+    max_num_batched_tokens: 32768
+    max_num_seqs: 1
+    gpu_memory_utilization: 0.5
+    enforce_eager: true
+    trust_remote_code: true
+    enable_prefix_caching: false
+    mm_processor_cache_gb: 0
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 2048
+      seed: 42
+      repetition_penalty: 1.1
+
+  - stage_id: 1          # talker (AR) — colocated on device 0
+    max_num_batched_tokens: 32768
+    max_num_seqs: 1
+    gpu_memory_utilization: 0.25
+    enforce_eager: true
+    trust_remote_code: true
+    enable_prefix_caching: false
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.9
+      top_p: 0.8
+      top_k: 40
+      max_tokens: 2048
+      seed: 42
+      repetition_penalty: 1.05
+
+  - stage_id: 2          # code2wav (DiT) — colocated on device 0
+    max_num_batched_tokens: 32768
+    max_num_seqs: 1
+    gpu_memory_utilization: 0.15
+    enforce_eager: true
+    trust_remote_code: true
+    enable_prefix_caching: false
+    enable_flashinfer_autotune: false
+    async_scheduling: false
+    devices: "0"
+    default_sampling_params:
+      temperature: 0.0
+      top_p: 1.0
+      top_k: -1
+      max_tokens: 2048
+      seed: 42
+      repetition_penalty: 1.1

--- a/scripts/qualify/tier2_omni.py
+++ b/scripts/qualify/tier2_omni.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Tier 2 (omni variant) — standalone functional inference for vLLM-Omni bundles.
+
+Runs INSTEAD OF tier2_inference.py when the candidate is an omni bundle (one
+built with the workflow's `omni: true` input — i.e. vllm_omni is installed). It
+boots the bundle's own `vllm-omni-server` on a small omni model with a
+single-GPU deploy config and exercises the OpenAI-compatible chat endpoint, so
+the qualification gate proves the omni multi-stage pipeline actually serves on
+the GPU — not just that plain vLLM loads.
+
+It emits a `tier2` fragment (same tier id as tier2_inference.py) so the existing
+aggregate `--require-tiers tier0,tier1,tier2` promotion rule is unchanged; the
+two scripts are mutually exclusive per run.
+
+Checks:
+  T2.1  omni server boot   — vllm-omni-server starts and /v1/models is ready (gating).
+  T2.2  chat completion    — /v1/chat/completions returns non-empty text (gating).
+  T2.3  streaming          — streamed chat yields content chunks + [DONE] (gating).
+
+Usage:
+    python3 tier2_omni.py --bundle-root ./vllm-install --gfx-target gfx1151 \
+        --model Qwen/Qwen2.5-Omni-3B --output tier2-gfx1151.json
+"""
+
+import argparse
+import glob
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+import bundle
+import report
+
+# Omni first-boot is slow: 3 stage engine cores + multimodal weight load +
+# per-kernel Triton JIT for the gfx target. Allow generous headroom.
+READY_TIMEOUT = 1800
+REQUEST_TIMEOUT = 600
+
+# Default deploy config shipped alongside this script (colocates all stages on
+# device 0 for single-GPU qualification hardware).
+DEFAULT_DEPLOY = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "deploy", "qwen2_5_omni_1gpu.yaml"
+)
+
+
+def http_post(url, payload, timeout=REQUEST_TIMEOUT, stream=False):
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    resp = urllib.request.urlopen(req, timeout=timeout)
+    if stream:
+        return resp
+    body = resp.read().decode("utf-8")
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return {"raw": body}
+
+
+def http_get(url, timeout=10):
+    try:
+        resp = urllib.request.urlopen(url, timeout=timeout)
+        return resp.status
+    except (urllib.error.URLError, OSError):
+        return None
+
+
+def wait_ready(port, proc, timeout):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return False, f"server exited early (rc={proc.returncode})"
+        # Omni's frontend may not expose /health; /v1/models is the reliable
+        # readiness signal once all stages have registered.
+        if http_get(f"http://127.0.0.1:{port}/v1/models") == 200:
+            return True, None
+        if http_get(f"http://127.0.0.1:{port}/health") == 200:
+            return True, None
+        time.sleep(5)
+    return False, f"not ready within {timeout}s"
+
+
+def _tail(path, lines=60):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            return "\n".join(handle.read().splitlines()[-lines:])
+    except OSError:
+        return ""
+
+
+class OmniServer:
+    def __init__(self, root, model, deploy_config, port, log_path, max_model_len):
+        self.root = root
+        self.model = model
+        self.deploy_config = deploy_config
+        self.port = port
+        self.log_path = log_path
+        self.max_model_len = max_model_len
+        self.proc = None
+
+    def start(self):
+        launcher = os.path.join(self.root, "bin", "vllm-omni-server")
+        log = open(self.log_path, "w", encoding="utf-8")
+        self.proc = subprocess.Popen(
+            [
+                launcher,
+                "serve", self.model,
+                "--omni",
+                "--deploy-config", self.deploy_config,
+                "--host", "127.0.0.1",
+                "--port", str(self.port),
+                "--max-model-len", str(self.max_model_len),
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+
+    def stop(self):
+        if self.proc and self.proc.poll() is None:
+            try:
+                os.killpg(os.getpgid(self.proc.pid), signal.SIGTERM)
+                self.proc.wait(timeout=30)
+            except (ProcessLookupError, subprocess.TimeoutExpired):
+                try:
+                    os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+
+
+def sweep_orphans():
+    """Last-resort kill of straggler omni server/stage processes (VRAM).
+
+    Runs only AFTER the report is written. Anchored to the omni server's own
+    process titles — the omni CLI entrypoint and its StageEngineCoreProc /
+    EngineCore children + the multiprocessing resource_tracker — NOT bare
+    "vllm" (which would also match this harness; see tier2_inference.py).
+    """
+    subprocess.run(
+        [
+            "pkill", "-9", "-if",
+            r"vllm_omni\.entrypoints|vllm\.entrypoints|StageEngineCore|"
+            r"VLLM::EngineCore|multiprocessing\.resource_tracker",
+        ],
+        check=False,
+    )
+
+
+# --------------------------------------------------------------------------
+# Checks
+# --------------------------------------------------------------------------
+
+
+def check_chat(base, model):
+    body = http_post(
+        f"{base}/v1/chat/completions",
+        {"model": model,
+         "messages": [{"role": "user", "content": "In one sentence, what is a lemon?"}],
+         "max_tokens": 64, "temperature": 0.0, "modalities": ["text"]},
+    )
+    msg = body.get("choices", [{}])[0].get("message", {})
+    content = (msg.get("content") or "") + (msg.get("reasoning") or "")
+    if content.strip():
+        return (report.STATUS_PASS, None, {"sample": content[:120]})
+    return (report.STATUS_FAIL, "empty chat content", {"body": body})
+
+
+def check_streaming(base, model):
+    resp = http_post(
+        f"{base}/v1/chat/completions",
+        {"model": model,
+         "messages": [{"role": "user", "content": "Say hello."}],
+         "max_tokens": 32, "temperature": 0.0, "modalities": ["text"],
+         "stream": True},
+        stream=True,
+    )
+    chunks = 0
+    saw_done = False
+    for raw in resp:
+        line = raw.decode("utf-8").strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:"):].strip()
+        if payload == "[DONE]":
+            saw_done = True
+            break
+        try:
+            delta = json.loads(payload)["choices"][0].get("delta", {})
+            if delta.get("content"):
+                chunks += 1
+        except (json.JSONDecodeError, KeyError, IndexError):
+            continue
+    if chunks > 0 and saw_done:
+        return (report.STATUS_PASS, None, {"chunks": chunks})
+    return (
+        report.STATUS_FAIL,
+        f"streaming incomplete (chunks={chunks}, done={saw_done})",
+        {},
+    )
+
+
+def detect_versions(root):
+    sp = bundle.find_site_packages(root)
+
+    def ver(project):
+        for meta in glob.glob(os.path.join(sp, f"{project}-*.dist-info", "METADATA")):
+            with open(meta, encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    if line.startswith("Version:"):
+                        return line.split(":", 1)[1].strip()
+        return None
+
+    torch_v = ver("torch")
+    rocm_v = None
+    if torch_v and "rocm" in torch_v:
+        match = re.search(r"rocm([\d.]+)", torch_v)
+        rocm_v = match.group(1) if match else None
+    # dist-info dirs normalize to underscores: vllm_omni-<ver>.dist-info
+    return ver("vllm"), torch_v, rocm_v, ver("vllm_omni")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Tier 2 omni functional inference")
+    parser.add_argument("--bundle-root", required=True)
+    parser.add_argument("--gfx-target", required=True)
+    parser.add_argument("--channel", default=None, choices=[None, "stable", "nightly"])
+    # Smallest validated omni model. AR (thinker/talker/code2wav) — no diffusion.
+    parser.add_argument("--model", default="Qwen/Qwen2.5-Omni-3B")
+    parser.add_argument("--deploy-config", default=DEFAULT_DEPLOY)
+    parser.add_argument("--max-model-len", type=int, default=4096)
+    parser.add_argument("--port", type=int, default=8193)
+    parser.add_argument("--candidate-tag", default=None)
+    parser.add_argument("--run-id", default=os.environ.get("GITHUB_RUN_ID"))
+    parser.add_argument("--run-attempt", default=os.environ.get("GITHUB_RUN_ATTEMPT"))
+    parser.add_argument("--logs-dir", default=".")
+    parser.add_argument("--output", default="tier2-report.json")
+    parser.add_argument("--ready-timeout", type=int, default=READY_TIMEOUT)
+    parser.add_argument("--fail-on-error", action="store_true")
+    args = parser.parse_args()
+
+    root = os.path.abspath(args.bundle_root)
+    vllm_v, torch_v, rocm_v, omni_v = detect_versions(root)
+    meta = report.build_meta(
+        gfx_target=args.gfx_target,
+        channel=args.channel,
+        vllm_version=vllm_v,
+        torch_version=torch_v,
+        rocm_version=rocm_v,
+        candidate_tag=args.candidate_tag,
+        hardware_validated=True,
+        run_id=args.run_id,
+        run_attempt=args.run_attempt,
+    )
+    tier = report.TierReport("tier2", meta)
+
+    if not omni_v:
+        # Not an omni bundle — caller routed wrong. Record a clear fail so the
+        # gate blocks rather than silently passing an omni-less bundle.
+        tier.add("T2.1", "omni server boot", report.STATUS_FAIL,
+                 error="vllm_omni not installed in bundle — not an omni build")
+        tier.write(args.output)
+        tier.print_summary()
+        sys.exit(1 if args.fail_on_error else 0)
+
+    if not os.path.exists(args.deploy_config):
+        tier.add("T2.1", "omni server boot", report.STATUS_FAIL,
+                 error=f"deploy config not found: {args.deploy_config}")
+        tier.write(args.output)
+        tier.print_summary()
+        sys.exit(1 if args.fail_on_error else 0)
+
+    os.makedirs(args.logs_dir, exist_ok=True)
+    log_path = os.path.join(args.logs_dir, f"vllm-omni-server-{args.gfx_target}.log")
+    base = f"http://127.0.0.1:{args.port}"
+    server = OmniServer(root, args.model, args.deploy_config, args.port,
+                        log_path, args.max_model_len)
+
+    try:
+        server.start()
+        ready, err = wait_ready(args.port, server.proc, args.ready_timeout)
+        if ready:
+            tier.add("T2.1", "omni server boot", report.STATUS_PASS,
+                     details={"model": args.model, "vllm_omni": omni_v})
+        else:
+            tier.add("T2.1", "omni server boot", report.STATUS_FAIL, error=err,
+                     details={"log_tail": _tail(log_path)})
+
+        if ready:
+            tier.run("T2.2", "chat completion",
+                     lambda: check_chat(base, args.model))
+            tier.run("T2.3", "streaming",
+                     lambda: check_streaming(base, args.model))
+        else:
+            for tid, name in [("T2.2", "chat completion"), ("T2.3", "streaming")]:
+                tier.add(tid, name, report.STATUS_SKIP, error="server not ready")
+    finally:
+        server.stop()
+
+    tier.write(args.output)
+    tier.print_summary()
+    print(f"\nWrote {args.output}")
+
+    sweep_orphans()
+
+    if args.fail_on_error and tier.rollup_status() == report.STATUS_FAIL:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds **vLLM-Omni** support to the portable-bundle pipeline so omni / any-to-any
multimodal models (Qwen-Omni today; Cosmos3 later) can run with ROCm
acceleration on AMD GPUs (validated on **gfx1151 / Strix Halo**).

vLLM-Omni is a **pure-Python layer** with no kernels of its own — so the omni
bundle is the *same* relocatable base bundle (Python + torch + vLLM + ROCm SDK
+ Triton) **plus** `vllm-omni`, its deps, an ABI-matched `torchaudio`, and a
`vllm-omni-server` launcher. It rides the base's gfx code objects, so omni
models get the same ROCm acceleration as plain vLLM.

## How

- **`scripts/build_omni_layer.sh`** — turns a built base bundle into an omni
  bundle (auto-matches `vllm-omni` to the base vLLM major.minor, installs deps +
  torchaudio, writes the launcher, re-strips pip). Runs in the build job *after*
  Strip.
- **Separate release artifact** — `vllm-omni<ver>-rocm<ver>-<gfx>`, not folded
  into the lean LLM bundle (omni pulls ~1 GB of extra deps).
- **Opt-in `omni: true` dispatch input** + **daily auto-build cron** (16:30 UTC,
  gfx1151) that builds → qualifies → publishes on green. Plain nightly/stable
  builds are unchanged.
- **Omni qualification** — `scripts/qualify/tier2_omni.py` boots
  `vllm-omni-server` on Qwen2.5-Omni-3B with a single-GPU deploy config
  (`scripts/qualify/deploy/qwen2_5_omni_1gpu.yaml`) and checks boot / chat /
  streaming. Emits a `tier2` fragment (runs instead of `tier2_inference.py` on
  omni builds), so the promotion rule is unchanged.

## Validation (real CI, dev_lab gfx1151)

End-to-end green in [run 28468657941](https://github.com/lemonade-sdk/vllm-rocm/actions/runs/28468657941):
`build-ubuntu` (base → Strip → omni layer) + `qualify` (tier0 + tier1 +
**tier2_omni**) → **promoted**. Also verified locally: omni serves text **and
native voice** (talker→token2wav, 24 kHz WAV) on gfx1151, and the layer builds
on a pristine post-Strip base.

Two CI-caught bugs fixed in the dry-runs: qualify was gated to release-only
(omni dry-runs skipped it), and the layer left pip in the bundle (T0.4 bloat
WARN blocked promotion).

## Notes

- Validation runs used `create_release: false` (no publish). The daily cron and
  a `create_release: true` dispatch publish the artifact (gated on green).
- Omni is not deduped like plain nightly (rebuilds daily) — a follow-up
  optimization if runner time becomes a concern.
- The cron-triggered path is logic-reviewed; cron firing itself validates on its
  first scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)