### PR TITLE
fix(omni): make the omni build work on cp314 + pin the qualified base

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -61,6 +61,13 @@ env:
   # pure-Python layer; the omni bundle is the base bundle + vllm-omni + its deps
   # (see scripts/build_omni_layer.sh). Off for normal nightly/stable runs.
   OMNI: ${{ github.event.inputs.omni || (github.event.schedule == '30 16 * * *') || 'false' }}
+  # Qualified base the omni layer builds on. vLLM-Omni 0.23.0rc1 does NOT support
+  # the bleeding-edge nightly base (its transformers 5.13 breaks ming.py's
+  # AutoFeatureExtractor.register; numpy 2.5 breaks numba/openai-whisper), so
+  # omni builds pin this validated base instead of tracking the latest nightly.
+  # Bump when a newer vLLM-Omni supports a newer base. (Used in the nightly
+  # install step below.)
+  OMNI_BASE_VLLM_VER: "0.23.1.dev0+rocm7.14.0a20260624.g0fc695fc6.d20260625"
 
 jobs:
   # Decide whether AMD has published a nightly vLLM wheel we have not already
@@ -339,6 +346,14 @@ jobs:
             ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
           fi
           [ -n "$VLLM_VER" ] || { echo "::error::no cp314 nightly vLLM version found"; exit 1; }
+          # Omni builds pin the qualified base (vLLM-Omni 0.23.0rc1 can't ride
+          # the latest nightly — see OMNI_BASE_VLLM_VER). Override the detected
+          # version so build/qualify/release all use the validated base.
+          if [ "$OMNI" = "true" ]; then
+            VLLM_VER="$OMNI_BASE_VLLM_VER"
+            ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
+            echo "omni: pinning base to $VLLM_VER (stamp $ROCM_STAMP)"
+          fi
           # upstream vLLM 0.21.x pins torch 2.11.0 (the wheel itself strips it);
           # bump TORCH_VER here when vLLM bumps its torch requirement.
           TORCH_VER=2.11.0

--- a/scripts/build_omni_layer.sh
+++ b/scripts/build_omni_layer.sh
@@ -118,17 +118,19 @@ PY
 )
 [ "${#OMNI_REQS[@]}" -gt 0 ] || { echo "::error::no vllm-omni runtime deps parsed"; exit 1; }
 
-# Multimodal deps the base bundle trims but omni model loading needs, plus
-# resolver guards for the openai-whisper -> numba -> llvmlite chain on cp314:
-# the base bundle ships llvmlite 0.47 (pinned), which no cp314 numba wheel pairs
-# with, so pip backtracks to the numba 0.62 sdist (setup.py rejects 3.14).
-# Floor numba above the sdist and force llvmlite past 0.47 so pip stays on
-# wheels (numba 0.66 + llvmlite 0.48, both cp314). llvmlite's only consumer is
-# numba, so bumping it is safe for the rest of the bundle.
-OMNI_EXTRAS=(timm opencv-python-headless peft "numba>=0.63" "llvmlite>=0.48")
+# Multimodal deps the base bundle trims but omni model loading needs.
+OMNI_EXTRAS=(timm opencv-python-headless peft)
 
+# --only-binary=numba,llvmlite: openai-whisper pulls numba, whose sdist
+# (setup.py) refuses Python 3.14, and the base bundle pins llvmlite 0.47. The
+# numba 0.65.x WHEELS accept llvmlite 0.47, so forbidding the numba/llvmlite
+# sdists makes pip settle on that wheel instead of backtracking into the numba
+# 0.62 sdist. Do NOT try to force llvmlite up (it's pinned in the bundle, so
+# >=0.48 is ResolutionImpossible); pip picks the numba wheel that matches
+# whatever llvmlite the base ships.
 echo "== installing ${#OMNI_REQS[@]} vllm-omni deps + ${#OMNI_EXTRAS[@]} multimodal extras"
-"$PYBIN" -m pip install -c "$CONSTRAINTS" "${OMNI_REQS[@]}" "${OMNI_EXTRAS[@]}"
+"$PYBIN" -m pip install --only-binary=numba,llvmlite -c "$CONSTRAINTS" \
+  "${OMNI_REQS[@]}" "${OMNI_EXTRAS[@]}"
 
 # --- re-strip pip (we bootstrapped it above) to match the base bundle --------
 # The base Strip step removes pip; we re-added it only to install this layer.

--- a/scripts/build_omni_layer.sh
+++ b/scripts/build_omni_layer.sh
@@ -82,23 +82,47 @@ if ! "$PYBIN" -c 'import torchaudio' >/dev/null 2>&1; then
 fi
 
 # --- vllm-omni + runtime deps ------------------------------------------------
-# --ignore-requires-python: every vllm-omni release pins Python <3.14, but the
-# qualified nightly base is cp314. The cap is conservative — validated to run on
-# 3.14 — and this is a bundle we control + qualify, so we override it here. (The
-# base install already uses --ignore-requires-python for amd-quark's cp<3.13 cap.)
-OMNI_DEPS=(
-  aenum omegaconf "diffusers==0.38.0" "cache-dit==1.3.0" x-transformers torchsde
-  janus prettytable av soundfile einops "openai-whisper" onnxruntime "imageio[ffmpeg]"
-  # multimodal deps the base bundle trims but omni model loading needs:
-  timm opencv-python-headless peft
-)
-# vllm-omni's own Requires-Dist (incl. fa3-fwd) is pulled by naming it as a
-# top-level requirement below; OMNI_DEPS only adds the multimodal extras the
-# base trim drops plus exact-pinned deps for resolver stability.
+# Two-step install so --ignore-requires-python is scoped to vllm-omni ONLY.
+#
+# 1. vllm-omni itself: every release pins Python <3.14, but the qualified nightly
+#    base is cp314. The cap is conservative (validated to run on 3.14) and this
+#    is a bundle we control + qualify, so we override it with
+#    --ignore-requires-python + --no-deps.
+# 2. Its runtime deps (+ the multimodal extras the base trim drops), installed
+#    WITHOUT that flag. Passed to the whole resolve, the flag strips the
+#    Python-version filter from every transitive dep too, so pip picked
+#    numba 0.62 (no cp314 wheel -> sdist -> setup.py refuses 3.14) over
+#    numba 0.63 (has a cp314 wheel). Scoping it here is the same pattern the
+#    base install uses for amd-quark.
+echo "== installing vllm-omni==$VLLM_OMNI_VER (no-deps)"
+"$PYBIN" -m pip install --no-deps --ignore-requires-python "vllm-omni==$VLLM_OMNI_VER"
 
-echo "== installing vllm-omni==$VLLM_OMNI_VER + ${#OMNI_DEPS[@]} deps"
-"$PYBIN" -m pip install --ignore-requires-python -c "$CONSTRAINTS" \
-  "vllm-omni==$VLLM_OMNI_VER" "${OMNI_DEPS[@]}"
+# Read vllm-omni's core (non-extra) runtime deps from its metadata so this tracks
+# the installed version instead of a hand-maintained list.
+mapfile -t OMNI_REQS < <("$PYBIN" - "$SP" <<'PY'
+import glob, os, sys
+sp = sys.argv[1]
+metas = glob.glob(os.path.join(sp, "vllm_omni-*.dist-info", "METADATA"))
+if not metas:
+    sys.exit("vllm_omni dist-info not found after install")
+for line in open(metas[0], encoding="utf-8", errors="replace"):
+    if not line.startswith("Requires-Dist:"):
+        continue
+    spec = line.split(":", 1)[1].strip()
+    if "extra ==" in spec:                  # skip optional extras (dev/demo/…)
+        continue
+    spec = spec.split(";", 1)[0].strip()    # drop any environment marker
+    if spec:
+        print(spec)
+PY
+)
+[ "${#OMNI_REQS[@]}" -gt 0 ] || { echo "::error::no vllm-omni runtime deps parsed"; exit 1; }
+
+# Multimodal deps the base bundle trims but omni model loading needs.
+OMNI_EXTRAS=(timm opencv-python-headless peft)
+
+echo "== installing ${#OMNI_REQS[@]} vllm-omni deps + ${#OMNI_EXTRAS[@]} multimodal extras"
+"$PYBIN" -m pip install -c "$CONSTRAINTS" "${OMNI_REQS[@]}" "${OMNI_EXTRAS[@]}"
 
 # --- re-strip pip (we bootstrapped it above) to match the base bundle --------
 # The base Strip step removes pip; we re-added it only to install this layer.

--- a/scripts/build_omni_layer.sh
+++ b/scripts/build_omni_layer.sh
@@ -118,8 +118,14 @@ PY
 )
 [ "${#OMNI_REQS[@]}" -gt 0 ] || { echo "::error::no vllm-omni runtime deps parsed"; exit 1; }
 
-# Multimodal deps the base bundle trims but omni model loading needs.
-OMNI_EXTRAS=(timm opencv-python-headless peft)
+# Multimodal deps the base bundle trims but omni model loading needs, plus
+# resolver guards for the openai-whisper -> numba -> llvmlite chain on cp314:
+# the base bundle ships llvmlite 0.47 (pinned), which no cp314 numba wheel pairs
+# with, so pip backtracks to the numba 0.62 sdist (setup.py rejects 3.14).
+# Floor numba above the sdist and force llvmlite past 0.47 so pip stays on
+# wheels (numba 0.66 + llvmlite 0.48, both cp314). llvmlite's only consumer is
+# numba, so bumping it is safe for the rest of the bundle.
+OMNI_EXTRAS=(timm opencv-python-headless peft "numba>=0.63" "llvmlite>=0.48")
 
 echo "== installing ${#OMNI_REQS[@]} vllm-omni deps + ${#OMNI_EXTRAS[@]} multimodal extras"
 "$PYBIN" -m pip install -c "$CONSTRAINTS" "${OMNI_REQS[@]}" "${OMNI_EXTRAS[@]}"

--- a/scripts/build_omni_layer.sh
+++ b/scripts/build_omni_layer.sh
@@ -164,9 +164,13 @@ chmod +x "$VLLM_ROOT/bin/vllm-omni-server"
 
 # --- verify the layer imports under the launcher env ------------------------
 echo "== verifying vllm_omni import"
-LD_LIBRARY_PATH="$SP/_rocm_sdk_core/lib/llvm/lib" \
-PYTHONPATH="$SP/_rocm_sdk_core/share/amd_smi" \
-  "$VLLM_ROOT/bin/vllm-omni-server" --help >/dev/null 2>&1 \
-  || { echo "::error::vllm-omni-server failed to import"; exit 1; }
+if ! LD_LIBRARY_PATH="$SP/_rocm_sdk_core/lib/llvm/lib" \
+     PYTHONPATH="$SP/_rocm_sdk_core/share/amd_smi" \
+     "$VLLM_ROOT/bin/vllm-omni-server" --help > /tmp/omni-verify.log 2>&1; then
+  echo "::error::vllm-omni-server failed to import"
+  echo "----- vllm-omni-server --help output (last 60 lines) -----"
+  tail -60 /tmp/omni-verify.log
+  exit 1
+fi
 
 echo "== omni layer complete: vllm-omni==$VLLM_OMNI_VER on vLLM $BASE_VLLM"

--- a/scripts/build_omni_layer.sh
+++ b/scripts/build_omni_layer.sh
@@ -60,12 +60,14 @@ PY
 echo "== base vLLM=$BASE_VLLM (mm=$BASE_MM) torch=$TORCH_VER -> vllm-omni==$VLLM_OMNI_VER"
 
 # Protect the GPU-coupled stack so dep resolution can never swap the ROCm
-# torch/vllm/triton/transformers for a PyPI build. safetensors/accelerate are
-# left to float (diffusers 0.38 needs safetensors>=0.8).
+# torch/vllm/triton for a PyPI build. safetensors/accelerate float (diffusers
+# 0.38 needs safetensors>=0.8). transformers is deliberately NOT protected: the
+# base ships 5.13, but vLLM-Omni 0.23.0rc1's ming.py uses the pre-5.13
+# AutoFeatureExtractor.register(str, ...) API, so we pin it <5.13 below.
 CONSTRAINTS=/tmp/omni-constraints.txt
 "$PYBIN" - > "$CONSTRAINTS" <<'PY'
 import importlib.metadata as m
-for p in ("torch","vllm","pytorch-triton-rocm","triton","torchvision","torchaudio","transformers","numpy"):
+for p in ("torch","vllm","pytorch-triton-rocm","triton","torchvision","torchaudio","numpy"):
     try: print(f"{p}=={m.version(p)}")
     except Exception: pass
 PY
@@ -127,8 +129,13 @@ PY
 )
 [ "${#OMNI_REQS[@]}" -gt 0 ] || { echo "::error::no vllm-omni runtime deps parsed"; exit 1; }
 
-# Multimodal deps the base bundle trims but omni model loading needs.
-OMNI_EXTRAS=(timm opencv-python-headless peft)
+# Multimodal deps the base bundle trims but omni model loading needs, plus a
+# transformers cap: vLLM-Omni 0.23.0rc1 eagerly imports ming.py, which calls the
+# pre-5.13 AutoFeatureExtractor.register(str, ...) API. transformers 5.13
+# changed it (expects a config class -> AttributeError on import). Pin <5.13
+# (resolves to 5.12.x, what the qualified base shipped); downgrades the base's
+# 5.13 for the omni bundle. vLLM 0.23.1 works with 5.12 (the qualified base did).
+OMNI_EXTRAS=(timm opencv-python-headless peft "transformers<5.13")
 
 echo "== installing ${#OMNI_REQS[@]} vllm-omni deps + ${#OMNI_EXTRAS[@]} multimodal extras"
 "$PYBIN" -m pip install -c "$CONSTRAINTS" "${OMNI_REQS[@]}" "${OMNI_EXTRAS[@]}"

--- a/scripts/build_omni_layer.sh
+++ b/scripts/build_omni_layer.sh
@@ -112,8 +112,17 @@ for line in open(metas[0], encoding="utf-8", errors="replace"):
     if "extra ==" in spec:                  # skip optional extras (dev/demo/…)
         continue
     spec = spec.split(";", 1)[0].strip()    # drop any environment marker
-    if spec:
-        print(spec)
+    if not spec:
+        continue
+    # openai-whisper pulls numba, which caps numpy<2.5; the nightly base ships
+    # numpy>=2.5, so numba is uninstallable here. openai-whisper (import whisper)
+    # is only used by the magi_human / ming model paths — not Qwen-Omni, the
+    # server entrypoint, or `import vllm_omni` — so skip it. The omni bundle
+    # still serves the models we ship + qualify. (Verified: vllm-omni-server
+    # imports fine without it.)
+    if spec.lower().startswith("openai-whisper"):
+        continue
+    print(spec)
 PY
 )
 [ "${#OMNI_REQS[@]}" -gt 0 ] || { echo "::error::no vllm-omni runtime deps parsed"; exit 1; }
@@ -121,16 +130,8 @@ PY
 # Multimodal deps the base bundle trims but omni model loading needs.
 OMNI_EXTRAS=(timm opencv-python-headless peft)
 
-# --only-binary=numba,llvmlite: openai-whisper pulls numba, whose sdist
-# (setup.py) refuses Python 3.14, and the base bundle pins llvmlite 0.47. The
-# numba 0.65.x WHEELS accept llvmlite 0.47, so forbidding the numba/llvmlite
-# sdists makes pip settle on that wheel instead of backtracking into the numba
-# 0.62 sdist. Do NOT try to force llvmlite up (it's pinned in the bundle, so
-# >=0.48 is ResolutionImpossible); pip picks the numba wheel that matches
-# whatever llvmlite the base ships.
 echo "== installing ${#OMNI_REQS[@]} vllm-omni deps + ${#OMNI_EXTRAS[@]} multimodal extras"
-"$PYBIN" -m pip install --only-binary=numba,llvmlite -c "$CONSTRAINTS" \
-  "${OMNI_REQS[@]}" "${OMNI_EXTRAS[@]}"
+"$PYBIN" -m pip install -c "$CONSTRAINTS" "${OMNI_REQS[@]}" "${OMNI_EXTRAS[@]}"
 
 # --- re-strip pip (we bootstrapped it above) to match the base bundle --------
 # The base Strip step removes pip; we re-added it only to install this layer.


### PR DESCRIPTION
Follow-up to #23. The omni build (`omni: true`) failed on the current nightly base; this makes it green and **publishes `vllm-omni0.23.0rc1-rocm7.14.0-gfx1151`** (verified: build + qualify tier2_omni + create-release all pass).

The nightly base had advanced past what vLLM-Omni 0.23.0rc1 supports, so several layered fixes in `scripts/build_omni_layer.sh` + the workflow:

- **Scope `--ignore-requires-python` to vllm-omni only** (`--no-deps`), install its deps (read from metadata) without it — a global flag made pip pick the numba 0.62 sdist (rejects py3.14).
- **Drop `openai-whisper`** — it pulls numba, which caps `numpy<2.5` while the base ships numpy≥2.5. `import whisper` is only used by the magi_human/ming paths (not Qwen-Omni or the server import); verified `vllm-omni-server` imports without it.
- **Pin `transformers<5.13`** — vLLM-Omni 0.23.0rc1's `ming.py` (eagerly imported by the server) uses the pre-5.13 `AutoFeatureExtractor.register(str, ...)` API; 5.13 changed it → `AttributeError` on import. 5.12.x is what the qualified base shipped.
- **Pin the omni base** to `OMNI_BASE_VLLM_VER` (the qualified `0.23.1.dev0+rocm7.14.0a20260624`) instead of tracking the latest nightly — vLLM-Omni should ride a validated base, not the daily edge.
- Verify step now surfaces the launcher import error instead of swallowing it.

Each step was diagnosed from the actual CI error and reproduced locally against the cp314 base before dispatching. Confirmed end-to-end green on the dev_lab gfx1151 runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)