### PR TITLE
feat: add CDNA3 (gfx942) and CDNA4 (gfx950) as build targets

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -286,6 +286,13 @@ jobs:
               exit 1
             fi
             ;;
+          gfx950)
+            suffix="gfx950-dcgpu"
+            if [ "$CHANNEL" != "stable" ]; then
+              echo "::error::gfx950 requires channel=stable — AMD publishes no CDNA nightly vLLM wheel"
+              exit 1
+            fi
+            ;;
           *)
             echo "ERROR: No AMD pre-built wheels for target: $target"
             exit 1

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -278,6 +278,14 @@ jobs:
           gfx1151) suffix="gfx1151" ;;
           gfx1150) suffix="gfx1150" ;;
           gfx120X) suffix="gfx120X-all" ;;
+          # AMD's nightly vLLM line is device-all-RDNA: CDNA is stable-only.
+          gfx942)
+            suffix="gfx94X-dcgpu"
+            if [ "$CHANNEL" != "stable" ]; then
+              echo "::error::gfx942 requires channel=stable — AMD publishes no CDNA nightly vLLM wheel"
+              exit 1
+            fi
+            ;;
           *)
             echo "ERROR: No AMD pre-built wheels for target: $target"
             exit 1
@@ -1042,6 +1050,12 @@ jobs:
 
         # Extract ROCm version from torch version string
         ROCM_VERSION=$(echo "$TORCH_VERSION" | grep -oP 'rocm[\d.]+' || echo "rocm")
+
+        # Some AMD stable wheels stamp __version__ with +local metadata; stable tags
+        # carry the public version only. Nightly keeps the full version by design.
+        if [ "$CHANNEL" = "stable" ]; then
+          VLLM_VERSION="${VLLM_VERSION%%+*}"
+        fi
 
         # Omni builds release as a SEPARATE artifact, tagged by the vllm-omni
         # version so it never collides with the plain-vLLM bundle:

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -91,6 +91,9 @@ jobs:
         set -uo pipefail
         IS_NEW=true
         if [ "$CHANNEL" = "nightly" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
+          # RDNA line: this job gates the DAILY CRON, which is RDNA-driven. CDNA
+          # targets resolve their own version in the build step from
+          # device-all-cdna, so dedup here is deliberately RDNA-keyed.
           NIGHTLY_VLLM=https://rocm.frameworks-nightlies.amd.com/whl/device-all-rdna
           # AMD's nightly vLLM is cp314 (Python 3.14); the old cp313 line is frozen.
           WHL=$(curl -fsSL "$NIGHTLY_VLLM/vllm/" \
@@ -278,21 +281,11 @@ jobs:
           gfx1151) suffix="gfx1151" ;;
           gfx1150) suffix="gfx1150" ;;
           gfx120X) suffix="gfx120X-all" ;;
-          # AMD's nightly vLLM line is device-all-RDNA: CDNA is stable-only.
-          gfx942)
-            suffix="gfx94X-dcgpu"
-            if [ "$CHANNEL" != "stable" ]; then
-              echo "::error::gfx942 requires channel=stable — AMD publishes no CDNA nightly vLLM wheel"
-              exit 1
-            fi
-            ;;
-          gfx950)
-            suffix="gfx950-dcgpu"
-            if [ "$CHANNEL" != "stable" ]; then
-              echo "::error::gfx950 requires channel=stable — AMD publishes no CDNA nightly vLLM wheel"
-              exit 1
-            fi
-            ;;
+          # CDNA. These suffixes are the STABLE-channel per-card aisles; the
+          # nightly channel uses AMD's device-all-cdna line instead (resolved in
+          # the install step, which is the only place the channel is known).
+          gfx942) suffix="gfx94X-dcgpu" ;;
+          gfx950) suffix="gfx950-dcgpu" ;;
           *)
             echo "ERROR: No AMD pre-built wheels for target: $target"
             exit 1
@@ -398,8 +391,18 @@ jobs:
           # universal RDNA vLLM wheel plus a date-stamped matched torch; we pair
           # them by the shared ROCm build stamp (rocm7.14.0a<DATE>), so the set
           # is ABI-consistent by construction — no pinning around mismatches.
-          NIGHTLY_VLLM=https://rocm.frameworks-nightlies.amd.com/whl/device-all-rdna
+          # AMD publishes the nightly vLLM as TWO separate per-family lines,
+          # device-all-rdna and device-all-cdna, at independent versions. The
+          # line must therefore follow the matrix target, not be hardcoded.
+          # (torch does NOT: whl-multi-arch carries every arch, including
+          # rocm-sdk-device-gfx942/-gfx950, so the torch half is family-agnostic.)
+          case "${{ matrix.gfx_target }}" in
+            gfx942|gfx950) NIGHTLY_SET=device-all-cdna ;;
+            *)             NIGHTLY_SET=device-all-rdna ;;
+          esac
+          NIGHTLY_VLLM=https://rocm.frameworks-nightlies.amd.com/whl/$NIGHTLY_SET
           NIGHTLY_TORCH=https://rocm.nightlies.amd.com/whl-multi-arch
+          echo "nightly vLLM line: $NIGHTLY_SET"
           # torch's per-gfx kernels are an extra; map the matrix target to it.
           case "${{ matrix.gfx_target }}" in
             gfx1151) DEV=gfx1151 ;;
@@ -411,8 +414,17 @@ jobs:
           # 1. Use the version detect-nightly already resolved (so detect and
           #    build agree even if AMD publishes a newer one mid-run); else
           #    discover the newest cp314 wheel from the index.
-          VLLM_VER="${{ needs.detect-nightly.outputs.vllm_ver }}"
-          ROCM_STAMP="${{ needs.detect-nightly.outputs.rocm_stamp }}"
+          # detect-nightly probes the RDNA line only (it gates the daily cron),
+          # so its version is valid for RDNA targets ONLY. Reusing it for a CDNA
+          # build would pin a version that does not exist on the CDNA line; leave
+          # it empty so the self-discovery below resolves from $NIGHTLY_VLLM.
+          if [ "$NIGHTLY_SET" = "device-all-rdna" ]; then
+            VLLM_VER="${{ needs.detect-nightly.outputs.vllm_ver }}"
+            ROCM_STAMP="${{ needs.detect-nightly.outputs.rocm_stamp }}"
+          else
+            VLLM_VER=""
+            ROCM_STAMP=""
+          fi
           if [ -z "$VLLM_VER" ]; then
             WHL=$(curl -fsSL "$NIGHTLY_VLLM/vllm/" \
               | grep -oE 'vllm-[0-9][^"]*-cp314-cp314-linux_x86_64\.whl' \


### PR DESCRIPTION
Adds the two CDNA families as build targets: gfx942 (MI300X/CDNA3) and gfx950 (MI350X-class/CDNA4).

Both channels work. Stable resolves the per-card dcgpu aisles (`gfx94X-dcgpu`, `gfx950-dcgpu`). Nightly resolves AMD's `device-all-cdna` line, which sits at an independent version from `device-all-rdna` (0.23.1.dev0 vs 0.25.2.dev0 today), so the nightly vLLM index is now selected from the matrix target instead of being hardcoded to RDNA.

torch needed no equivalent change: the nightly torch index is `whl-multi-arch`, which already carries `rocm-sdk-device-gfx942` and `-gfx950`, and the existing per-gfx `DEV` mapping already falls through to the right value for CDNA.

`detect-nightly` still probes the RDNA line only, since it gates the daily cron. Its resolved version is therefore reused for RDNA targets only; CDNA self-discovers from its own line via the existing fallback. RDNA behaviour is otherwise unchanged.

lemonade already ships the consuming side: `rocm_arch_overrides` pins gfx942 (since v11.0.0) and gfx950 (v11.5.0) to `vllm0.19.1-rocm7.13.0`, with the vLLM descriptor gated off CDNA until assets from this workflow exist.

**How tested**, including what we could not test:

- The wheel-assembly path this enables is exercised end to end by community builds from the same indices. The gfx942 bundle is hardware-validated on a real MI300X (Qwen2.5-0.5B, warm single-stream 306-511 tok/s, CUDA graphs captured; separately Qwen3.6-27B-FP8 with MTP recipes). The gfx950 bundle built from `gfx950-dcgpu` wheels is build-validated (torch 2.10.0+rocm7.13.0, vLLM 0.19.1, import-proven).
- **Not tested: the nightly CDNA path has not been run.** It needs a runner with egress to `rocm.frameworks-nightlies.amd.com`, which 403s GitHub-hosted IPs. Our fork has no self-hosted runner, so this half wants a maintainer run before it is trusted.
- **Not tested: gfx950 on real CDNA4 hardware.** We have no MI350X access. The reporter on lemonade-sdk/lemonade#2686 runs an MI350X and is a natural first validator once an asset exists.

Current CDNA lines as of 2026-08-03: stable dcgpu is frozen at vLLM 0.19.1.dev3 + rocm7.13.0 (cp313, published 2026-05-13). Nightly reaches 0.21.1.dev0 + rocm7.14.0 on the per-card lines and 0.23.1.dev0 + rocm7.15.0 on `device-all-cdna`, both cp314.
