### PR TITLE
ci: parameterise the qualify job per gfx target

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -445,10 +445,15 @@ jobs:
           # bump TORCH_VER here when vLLM bumps its torch requirement. The
           # 0.23.1 base that omni builds pin predates that bump and its native
           # ext resolves against the torch 2.11 ABI, so it keeps 2.11.0.
+          # TV_VER is torch's strictly-paired torchvision (used by the repair
+          # step below); they move together or torchvision::nms fails to
+          # register and `import vllm` dies.
           if [ "$OMNI" = "true" ]; then
             TORCH_VER=2.11.0
+            TV_VER=0.26.0
           else
             TORCH_VER=2.12.0
+            TV_VER=0.27.0
           fi
           echo "nightly: vLLM==$VLLM_VER"
           echo "nightly: torch=${TORCH_VER}+${ROCM_STAMP}[device-${DEV}]"
@@ -504,9 +509,8 @@ jobs:
           #    torchvision must match the ROCm torch ABI or its C++ ops
           #    (torchvision::nms) fail to register and `import vllm` dies. Legacy
           #    pulled a PyPI torchvision built against a different torch; force the
-          #    matched ROCm build from the nightly index, same rocm stamp. torch
-          #    2.11 pairs with torchvision 0.26 — bump TV_VER with TORCH_VER.
-          TV_VER=0.26.0
+          #    matched ROCm build from the nightly index, same rocm stamp.
+          #    TV_VER is set alongside TORCH_VER above — they pair strictly.
           $VLLM_ROOT/bin/pip install --index-url "$NIGHTLY_TORCH" \
             --extra-index-url https://pypi.org/simple/ \
             "torchvision==${TV_VER}+${ROCM_STAMP}"

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -61,13 +61,13 @@ env:
   # pure-Python layer; the omni bundle is the base bundle + vllm-omni + its deps
   # (see scripts/build_omni_layer.sh). Off for normal nightly/stable runs.
   OMNI: ${{ github.event.inputs.omni || (github.event.schedule == '30 16 * * *') || 'false' }}
-  # Qualified base the omni layer builds on. vLLM-Omni 0.23.0rc1 does NOT support
-  # the bleeding-edge nightly base (its transformers 5.13 breaks ming.py's
-  # AutoFeatureExtractor.register; numpy 2.5 breaks numba/openai-whisper), so
-  # omni builds pin this validated base instead of tracking the latest nightly.
-  # Bump when a newer vLLM-Omni supports a newer base. (Used in the nightly
-  # install step below.)
-  OMNI_BASE_VLLM_VER: "0.23.1.dev0+rocm7.14.0a20260624.g0fc695fc6.d20260625"
+  # Qualified base the omni layer builds on: detect-omni resolves the newest
+  # vllm-omni release matching this base's major.minor from PyPI (0.25.x ->
+  # vllm-omni 0.25.0rc1). Pinned to a base that passed full qualification
+  # (run 31541098026) rather than tracking the latest nightly; bump when a
+  # newer base qualifies AND a matching vllm-omni release exists. (Used in
+  # the nightly install step below.)
+  OMNI_BASE_VLLM_VER: "0.25.2.dev0+rocm7.15.0a20260724.g752a3a504.d20260724"
 
 jobs:
   # Decide whether AMD has published a nightly vLLM wheel we have not already
@@ -442,19 +442,12 @@ jobs:
             echo "omni: pinning base to $VLLM_VER (stamp $ROCM_STAMP)"
           fi
           # upstream vLLM 0.25.x pins torch 2.12.0 (the wheel itself strips it);
-          # bump TORCH_VER here when vLLM bumps its torch requirement. The
-          # 0.23.1 base that omni builds pin predates that bump and its native
-          # ext resolves against the torch 2.11 ABI, so it keeps 2.11.0.
-          # TV_VER is torch's strictly-paired torchvision (used by the repair
-          # step below); they move together or torchvision::nms fails to
-          # register and `import vllm` dies.
-          if [ "$OMNI" = "true" ]; then
-            TORCH_VER=2.11.0
-            TV_VER=0.26.0
-          else
-            TORCH_VER=2.12.0
-            TV_VER=0.27.0
-          fi
+          # bump TORCH_VER here when vLLM bumps its torch requirement — and
+          # TV_VER with it: torchvision pairs strictly with torch (used by the
+          # repair step below) or torchvision::nms fails to register and
+          # `import vllm` dies. The omni base (0.25.x) shares this ABI.
+          TORCH_VER=2.12.0
+          TV_VER=0.27.0
           echo "nightly: vLLM==$VLLM_VER"
           echo "nightly: torch=${TORCH_VER}+${ROCM_STAMP}[device-${DEV}]"
           # 2. Matched torch + ROCm runtime libs + Triton + per-gfx kernels,

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -715,19 +715,25 @@ jobs:
         echo ""
         du -sh $VLLM_ROOT/*/ 2>/dev/null
 
+    - name: Create release archive
+      run: |
+        # tar.gz preserves the ROCm symlinks (upload-artifact's zip expands each
+        # symlink into a full copy of its target, bloating the artifact). tar
+        # also keeps the hidden per-gfx GPU code-object dirs (torch/.kpack/,
+        # _rocm_sdk_*/.kpack/, .devel_links/) that ROCm wheels ship, so
+        # include-hidden-files is no longer needed.
+        ARCHIVE="$RUNNER_TEMP/vllm-ubuntu-rocm-${{ matrix.gfx_target }}-x64.tar.gz"
+        tar -czf "$ARCHIVE" -C "$VLLM_ROOT" .
+        echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+        echo "Created $(du -h "$ARCHIVE" | cut -f1) archive"
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
         name: vllm-ubuntu-rocm-${{ matrix.gfx_target }}-x64
-        path: ${{ env.VLLM_ROOT }}/
-        # CRITICAL: the AMD ROCm wheels ship the per-gfx GPU code objects in
-        # HIDDEN dot-dirs (torch/.kpack/torch_gfx1151.kpack,
-        # _rocm_sdk_libraries/.kpack/{blas,fft,rand,rccl}_lib_gfx1151.kpack,
-        # .devel_links/). Since v4, upload-artifact EXCLUDES hidden files by
-        # default — dropping these silently produces a bundle that loads and
-        # enumerates the GPU but dies on the first kernel launch with
-        # hipErrorInvalidImage. include-hidden-files keeps them. Do not remove.
-        include-hidden-files: true
+        # Upload the intermediate tar.gz (not the raw bundle), so the artifact
+        # preserves symlinks and the hidden per-gfx code-object dirs on download.
+        path: ${{ env.ARCHIVE }}
         retention-days: 30
         compression-level: 6
 
@@ -805,7 +811,8 @@ jobs:
 
         # The build artifact is ~3.3 GB (extracts to ~11 GB). actions/download-artifact@v4
         # is unreliable for artifacts this size on self-hosted runners, so pull the
-        # artifact zip directly with curl (streams to disk, resumable) and unzip it.
+        # artifact zip directly with curl (streams to disk, resumable), unzip it to
+        # recover the release tar.gz, then untar it below.
         # Resolve the artifact id via the REST API with curl + python3 — the box
         # does not have the gh CLI installed.
         ART_ID=$(curl -fsSL \
@@ -839,19 +846,27 @@ jobs:
         echo "Downloaded zip: $(du -h "$ZIP" | cut -f1)"
 
         echo "=== Extracting ==="
+        # The artifact now holds the release tar.gz (not the raw bundle contents):
+        # unzip it, then untar so $DEST is the bundle root (bin/, lib/, ...).
+        # tar.gz preserves the ROCm symlinks the zip previously dropped.
         if command -v unzip >/dev/null 2>&1; then
-          unzip -q -o "$ZIP" -d "$DEST"
+          unzip -q -o "$ZIP" -d "$WORK/raw"
         else
-          python3 -m zipfile -e "$ZIP" "$DEST"
+          python3 -m zipfile -e "$ZIP" "$WORK/raw"
         fi
         rm -f "$ZIP"   # reclaim space immediately
+        TARBALL=$(find "$WORK/raw" -name '*.tar.gz' | head -n1)
+        [ -n "$TARBALL" ] || { echo "::error::no release archive in gfx1151 artifact"; exit 1; }
+        tar -xzf "$TARBALL" -C "$DEST"
+        rm -rf "$WORK/raw"
         echo "Extracted $(du -sh "$DEST" | cut -f1) to $DEST"
         echo "=== Disk after extract ==="; df -h "$WORK" || true
 
     - name: Restore permissions and ROCm symlinks
       run: |
-        # upload-artifact drops the +x bit and the unversioned .so symlinks the
-        # build created, so rebuild both before running the harness.
+        # upload-artifact's zip wrapper drops the +x bit (but the release tar.gz
+        # already preserved the unversioned .so symlinks), so restore the bits
+        # before running the harness.
         ROOT="${{ runner.temp }}/vllm-qual/vllm"
         # The bundle's Python version is channel-dependent (cp313 stable / cp314
         # nightly); glob it rather than hardcode.
@@ -1096,7 +1111,12 @@ jobs:
         base="${TAG}-x64"
 
         echo "Creating: ${base}.tar.gz"
-        tar -czf "${base}.tar.gz" -C ./artifact .
+        # The build job already produced the release archive (with ROCm symlinks
+        # preserved); reuse it instead of re-tarring the artifact, so the release
+        # asset structure stays identical.
+        src=$(find ./artifact -name '*.tar.gz' | head -n1)
+        [ -n "$src" ] || { echo "::error::no release archive in artifact for ${{ matrix.gfx_target }}"; exit 1; }
+        cp "$src" "${base}.tar.gz"
         size_mb=$(du -m "${base}.tar.gz" | cut -f1)
         echo "Archive size: ${size_mb} MB"
 

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -204,9 +204,11 @@ jobs:
           | sed 's/^ *//;s/ *$//' \
           | jq -R . \
           | jq -s --argjson q "$QUALIFIED_RUNNERS" \
-              '{include: [.[] | select($q[.] != null) | {gfx: ., runner_group: $q[.]}]}' \
+              'unique | {include: [.[] | select($q[.] != null) | {gfx: ., runner_group: $q[.]}]}' \
           | jq -c)
-        qualify_targets=$(echo "$qualify_matrix" | jq -r '[.include[].gfx] | join(",")')
+        # JSON array (not a comma list): consumers use fromJson() set membership,
+        # so no target string can substring-match another.
+        qualify_targets=$(echo "$qualify_matrix" | jq -c '[.include[].gfx]')
         qualify_count=$(echo "$qualify_matrix" | jq -r '.include | length')
         echo "qualify_matrix=$qualify_matrix" >> $GITHUB_OUTPUT
         echo "qualify_targets=$qualify_targets" >> $GITHUB_OUTPUT
@@ -1223,7 +1225,7 @@ jobs:
       # Co-locate the qualification proof with the shippable artifact, for any
       # target that was hardware-qualified this run; best-effort so it never
       # fails the release.
-      if: contains(needs.prepare-matrix.outputs.qualify_targets, matrix.gfx_target)
+      if: contains(fromJson(needs.prepare-matrix.outputs.qualify_targets), matrix.gfx_target)
       continue-on-error: true
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -441,9 +441,15 @@ jobs:
             ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
             echo "omni: pinning base to $VLLM_VER (stamp $ROCM_STAMP)"
           fi
-          # upstream vLLM 0.21.x pins torch 2.11.0 (the wheel itself strips it);
-          # bump TORCH_VER here when vLLM bumps its torch requirement.
-          TORCH_VER=2.11.0
+          # upstream vLLM 0.25.x pins torch 2.12.0 (the wheel itself strips it);
+          # bump TORCH_VER here when vLLM bumps its torch requirement. The
+          # 0.23.1 base that omni builds pin predates that bump and its native
+          # ext resolves against the torch 2.11 ABI, so it keeps 2.11.0.
+          if [ "$OMNI" = "true" ]; then
+            TORCH_VER=2.11.0
+          else
+            TORCH_VER=2.12.0
+          fi
           echo "nightly: vLLM==$VLLM_VER"
           echo "nightly: torch=${TORCH_VER}+${ROCM_STAMP}[device-${DEV}]"
           # 2. Matched torch + ROCm runtime libs + Triton + per-gfx kernels,

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -891,7 +891,7 @@ jobs:
         fi
         rm -f "$ZIP"   # reclaim space immediately
         TARBALL=$(find "$WORK/raw" -name '*.tar.gz' | head -n1)
-        [ -n "$TARBALL" ] || { echo "::error::no release archive in gfx1151 artifact"; exit 1; }
+        [ -n "$TARBALL" ] || { echo "::error::no release archive in ${GFX} artifact"; exit 1; }
         tar -xzf "$TARBALL" -C "$DEST"
         rm -rf "$WORK/raw"
         echo "Extracted $(du -sh "$DEST" | cut -f1) to $DEST"

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -175,6 +175,9 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       ubuntu_matrix: ${{ steps.set-matrix.outputs.ubuntu_matrix }}
+      qualify_matrix: ${{ steps.set-matrix.outputs.qualify_matrix }}
+      qualify_targets: ${{ steps.set-matrix.outputs.qualify_targets }}
+      qualify_count: ${{ steps.set-matrix.outputs.qualify_count }}
     steps:
     - name: Set matrix
       id: set-matrix
@@ -188,6 +191,27 @@ jobs:
           | jq -c)
         echo "ubuntu_matrix=$matrix_targets" >> $GITHUB_OUTPUT
         echo "Generated matrix: $matrix_targets"
+
+        # Targets with qualification hardware, mapped to the self-hosted runner
+        # group that owns each. The qualify job runs one leg per selected target
+        # that appears here; targets absent from this registry build and release
+        # exactly as before (qualify skips them -> release ungated, unchanged).
+        # Adding a runner for a new target (e.g. a CDNA box for gfx942) is a
+        # one-line addition to this map.
+        QUALIFIED_RUNNERS='{"gfx1151":"dev_lab"}'
+        qualify_matrix=$(echo "$targets" \
+          | tr ',' '\n' \
+          | sed 's/^ *//;s/ *$//' \
+          | jq -R . \
+          | jq -s --argjson q "$QUALIFIED_RUNNERS" \
+              '{include: [.[] | select($q[.] != null) | {gfx: ., runner_group: $q[.]}]}' \
+          | jq -c)
+        qualify_targets=$(echo "$qualify_matrix" | jq -r '[.include[].gfx] | join(",")')
+        qualify_count=$(echo "$qualify_matrix" | jq -r '.include | length')
+        echo "qualify_matrix=$qualify_matrix" >> $GITHUB_OUTPUT
+        echo "qualify_targets=$qualify_targets" >> $GITHUB_OUTPUT
+        echo "qualify_count=$qualify_count" >> $GITHUB_OUTPUT
+        echo "Qualify matrix: $qualify_matrix"
 
   build-ubuntu:
     # Target the dev_lab runner GROUP explicitly, not just labels. The org's
@@ -765,31 +789,37 @@ jobs:
         # No sudo — it's under the runner's temp dir. Free the box for the next run.
         rm -rf "$RUNNER_TEMP/vllm-build" || true
 
-  # 16-test qualification on the dev_lab Linux gfx1151 box. Targets the dev_lab
-  # runner GROUP (not just labels) so it can't land on a Linux box in another
-  # group the repo can also see (Default is visibility:all) — see build-ubuntu.
+  # 16-test qualification, one leg per selected target that has qualification
+  # hardware (prepare-matrix qualify_matrix: target -> self-hosted runner group;
+  # currently gfx1151 -> dev_lab). Targets the runner GROUP (not just labels) so
+  # a leg can't land on a Linux box in another group the repo can also see
+  # (Default is visibility:all) — see build-ubuntu.
   # Runs the scripts/qualify harness against the built bundle:
   #   tier0 static (6) + tier1 hardware smoke (5) + tier2 functional inference (5)
   # = 16 tests, then aggregates them into a qualification report and a promotion
   # decision. Releases are gated on promotion (see create-release `needs`).
   qualify:
-    needs: build-ubuntu
+    needs: [prepare-matrix, build-ubuntu]
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.qualify_matrix) }}
+      fail-fast: false
     runs-on:
-      group: dev_lab
+      group: ${{ matrix.runner_group }}
       labels: [self-hosted, Linux]
     env:
-      GFX: gfx1151
+      GFX: ${{ matrix.gfx }}
     # Runs on release builds AND on omni dispatches (omni is experimental —
     # always qualify it, even as a no-publish dry run; release stays gated on
-    # create_release in the create-release job). Skips PRs and dispatches that
-    # didn't select gfx1151 (nothing to test → release ungated).
+    # create_release in the create-release job). Skips PRs and dispatches whose
+    # selected targets have no qualification hardware (nothing to test →
+    # release ungated, matching the previous gfx1151-only behavior).
     if: >-
       github.event_name != 'pull_request' &&
+      needs.prepare-matrix.outputs.qualify_count != '0' &&
       (
         github.event_name == 'schedule' ||
         (
           github.event_name == 'workflow_dispatch' &&
-          contains(github.event.inputs.gfx_target, 'gfx1151') &&
           (
             github.event.inputs.create_release == 'true' ||
             github.event.inputs.create_release == null ||
@@ -801,7 +831,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Download gfx1151 artifact
+    - name: Download ${{ matrix.gfx }} artifact
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
@@ -822,8 +852,8 @@ jobs:
                    -H "Authorization: Bearer $GH_TOKEN" \
                    -H "Accept: application/vnd.github+json" \
                    "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-                 | python3 -c "import sys,json; print(next((a['id'] for a in json.load(sys.stdin)['artifacts'] if a['name']=='vllm-ubuntu-rocm-gfx1151-x64'), ''))")
-        [ -n "$ART_ID" ] || { echo "::error::gfx1151 artifact not found for this run"; exit 1; }
+                 | python3 -c "import sys,json,os; print(next((a['id'] for a in json.load(sys.stdin)['artifacts'] if a['name']==f\"vllm-ubuntu-rocm-{os.environ['GFX']}-x64\"), ''))")
+        [ -n "$ART_ID" ] || { echo "::error::${GFX} artifact not found for this run"; exit 1; }
         echo "Artifact id: $ART_ID"
 
         avail_gb=$(df -BG --output=avail "$WORK" | tail -1 | tr -dc '0-9')
@@ -943,7 +973,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: qualification-gfx1151
+        name: qualification-${{ matrix.gfx }}
         path: |
           ${{ runner.temp }}/vllm-qual/fragments/*.json
           ${{ runner.temp }}/vllm-qual/fragments/*.log
@@ -976,10 +1006,13 @@ jobs:
       with:
         path: repo
 
-    - name: Download qualification report
+    - name: Download qualification reports
       uses: actions/download-artifact@v4
       with:
-        name: qualification-gfx1151
+        # One artifact per qualified target; each lands in report/qualification-<gfx>/
+        # (merge-multiple stays off on purpose: every leg names its report
+        # qualification-report.json, so merging would clobber).
+        pattern: qualification-*
         path: report
 
     - name: Enrich summary prose (optional, best-effort)
@@ -987,22 +1020,28 @@ jobs:
       # in the report; this rewrites only its prose and never fails the job.
       if: env.ANTHROPIC_API_KEY != ''
       run: |
-        if [ ! -f report/qualification-report.json ]; then
-          echo "no report to enrich"; exit 0
-        fi
-        python3 -m pip install --quiet --disable-pip-version-check anthropic \
-          || { echo "::warning::pip install anthropic failed; skipping enrichment"; exit 0; }
-        python3 repo/scripts/qualify/enrich_summary.py \
-          --report report/qualification-report.json \
-          --model claude-haiku-4-5 || true
+        found=0
+        for rpt in report/qualification-*/qualification-report.json; do
+          [ -f "$rpt" ] || continue
+          if [ "$found" = 0 ]; then
+            python3 -m pip install --quiet --disable-pip-version-check anthropic \
+              || { echo "::warning::pip install anthropic failed; skipping enrichment"; exit 0; }
+          fi
+          found=1
+          python3 repo/scripts/qualify/enrich_summary.py \
+            --report "$rpt" \
+            --model claude-haiku-4-5 || true
+        done
+        [ "$found" = 1 ] || echo "no report to enrich"
 
     - name: Publish to qualification-data branch
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
-        if [ ! -f report/qualification-report.json ]; then
-          echo "::warning::no qualification-report.json in artifact; nothing to publish"
+        reports=$(ls report/qualification-*/qualification-report.json 2>/dev/null || true)
+        if [ -z "$reports" ]; then
+          echo "::warning::no qualification-report.json in any artifact; nothing to publish"
           exit 0
         fi
         git config --global user.name "github-actions[bot]"
@@ -1026,10 +1065,12 @@ jobs:
             git -C data rm -rf . >/dev/null 2>&1 || true
           fi
 
-          python3 repo/scripts/publish_qualification.py \
-            --report report/qualification-report.json \
-            --data-dir data/qualification \
-            --run-url "$RUN_URL"
+          for rpt in $reports; do
+            python3 repo/scripts/publish_qualification.py \
+              --report "$rpt" \
+              --data-dir data/qualification \
+              --run-url "$RUN_URL"
+          done
           # Keep the contract doc alongside the data on the branch.
           cp repo/docs/qualification-feed.md data/qualification/SCHEMA.md
 
@@ -1037,7 +1078,7 @@ jobs:
           if git -C data diff --cached --quiet; then
             echo "no changes to publish"; pushed=1; break
           fi
-          git -C data commit -q -m "qualification: run ${{ github.run_id }} (gfx1151)"
+          git -C data commit -q -m "qualification: run ${{ github.run_id }}"
           if git -C data push origin "$BRANCH" 2>/dev/null; then
             pushed=1; break
           fi
@@ -1178,17 +1219,18 @@ jobs:
         Portable vLLM build for $TARGET. Includes bundled Python, PyTorch ROCm, and ROCm runtime. No separate installation required." \
           $upload_files
 
-    - name: Attach qualification report to release (gfx1151)
-      # Co-locate the qualification proof with the shippable artifact. gfx1151 is
-      # the hardware-qualified target; best-effort so it never fails the release.
-      if: matrix.gfx_target == 'gfx1151'
+    - name: Attach qualification report to release
+      # Co-locate the qualification proof with the shippable artifact, for any
+      # target that was hardware-qualified this run; best-effort so it never
+      # fails the release.
+      if: contains(needs.prepare-matrix.outputs.qualify_targets, matrix.gfx_target)
       continue-on-error: true
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
         TAG="${{ steps.generate-tag.outputs.tag }}"
         rm -rf qual && mkdir -p qual
-        if ! gh run download "${{ github.run_id }}" -n qualification-gfx1151 -D qual --repo "${{ github.repository }}"; then
+        if ! gh run download "${{ github.run_id }}" -n "qualification-${{ matrix.gfx_target }}" -D qual --repo "${{ github.repository }}"; then
           echo "::warning::qualification artifact not found; skipping attach"; exit 0
         fi
         if [ -f qual/qualification-report.json ]; then

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -899,9 +899,9 @@ jobs:
 
     - name: Restore permissions and ROCm symlinks
       run: |
-        # upload-artifact's zip wrapper drops the +x bit (but the release tar.gz
-        # already preserved the unversioned .so symlinks), so restore the bits
-        # before running the harness.
+        # The artifact zip wraps a single tar.gz whose tar -xzf restores modes
+        # and the unversioned .so symlinks, so this is a defensive backstop
+        # (older raw-file artifacts lost +x), not a required repair.
         ROOT="${{ runner.temp }}/vllm-qual/vllm"
         # The bundle's Python version is channel-dependent (cp313 stable / cp314
         # nightly); glob it rather than hardcode.

--- a/scripts/build_omni_layer.sh
+++ b/scripts/build_omni_layer.sh
@@ -61,9 +61,8 @@ echo "== base vLLM=$BASE_VLLM (mm=$BASE_MM) torch=$TORCH_VER -> vllm-omni==$VLLM
 
 # Protect the GPU-coupled stack so dep resolution can never swap the ROCm
 # torch/vllm/triton for a PyPI build. safetensors/accelerate float (diffusers
-# 0.38 needs safetensors>=0.8). transformers is deliberately NOT protected: the
-# base ships 5.13, but vLLM-Omni 0.23.0rc1's ming.py uses the pre-5.13
-# AutoFeatureExtractor.register(str, ...) API, so we pin it <5.13 below.
+# 0.38 needs safetensors>=0.8). transformers is deliberately NOT protected:
+# vllm-omni's own Requires-Dist (applied via OMNI_REQS) governs its version.
 CONSTRAINTS=/tmp/omni-constraints.txt
 "$PYBIN" - > "$CONSTRAINTS" <<'PY'
 import importlib.metadata as m
@@ -73,14 +72,20 @@ for p in ("torch","vllm","pytorch-triton-rocm","triton","torchvision","torchaudi
 PY
 
 # --- ABI-matched torchaudio (omni api_server imports it eagerly) ------------
-# Not in the base bundle. Pull the build that matches the bundled torch
-# version+stamp from the same ROCm index the base used.
+# Not in the base bundle. torchaudio's version number no longer tracks
+# torch's (torch 2.12 pairs with torchaudio 2.11.0.x), so resolve the newest
+# torchaudio carrying the SAME ROCm build stamp as the bundled torch — same-
+# batch builds share the ABI regardless of the version number.
 if ! "$PYBIN" -c 'import torchaudio' >/dev/null 2>&1; then
-  echo "== installing torchaudio==$TORCH_VER from $TORCH_INDEX"
+  STAMP="${TORCH_VER#*+}"
+  TA_VER=$(curl -fsSL "${TORCH_INDEX:?set TORCH_INDEX to the base torch ROCm index}/torchaudio/" \
+    | grep -oE "torchaudio-[0-9][0-9.]*\+${STAMP}" | sed 's/^torchaudio-//' | sort -V | tail -1)
+  [ -n "$TA_VER" ] || { echo "::error::no torchaudio at stamp ${STAMP} on ${TORCH_INDEX}"; exit 1; }
+  echo "== installing torchaudio==$TA_VER from $TORCH_INDEX"
   "$PYBIN" -m pip install -c "$CONSTRAINTS" \
-    --index-url "${TORCH_INDEX:?set TORCH_INDEX to the base torch ROCm index}" \
+    --index-url "$TORCH_INDEX" \
     --extra-index-url https://pypi.org/simple/ \
-    "torchaudio==$TORCH_VER"
+    "torchaudio==$TA_VER"
 fi
 
 # --- vllm-omni + runtime deps ------------------------------------------------
@@ -129,13 +134,11 @@ PY
 )
 [ "${#OMNI_REQS[@]}" -gt 0 ] || { echo "::error::no vllm-omni runtime deps parsed"; exit 1; }
 
-# Multimodal deps the base bundle trims but omni model loading needs, plus a
-# transformers cap: vLLM-Omni 0.23.0rc1 eagerly imports ming.py, which calls the
-# pre-5.13 AutoFeatureExtractor.register(str, ...) API. transformers 5.13
-# changed it (expects a config class -> AttributeError on import). Pin <5.13
-# (resolves to 5.12.x, what the qualified base shipped); downgrades the base's
-# 5.13 for the omni bundle. vLLM 0.23.1 works with 5.12 (the qualified base did).
-OMNI_EXTRAS=(timm opencv-python-headless peft "transformers<5.13")
+# Multimodal deps the base bundle trims but omni model loading needs.
+# (vLLM-Omni 0.23 needed a transformers<5.13 cap for ming.py's pre-5.13
+# AutoFeatureExtractor API; 0.24+ supports 5.13, so vllm-omni's own
+# Requires-Dist — already applied via OMNI_REQS above — governs now.)
+OMNI_EXTRAS=(timm opencv-python-headless peft)
 
 echo "== installing ${#OMNI_REQS[@]} vllm-omni deps + ${#OMNI_EXTRAS[@]} multimodal extras"
 "$PYBIN" -m pip install -c "$CONSTRAINTS" "${OMNI_REQS[@]}" "${OMNI_EXTRAS[@]}"


### PR DESCRIPTION
Parameterises the `qualify` job off its hardcoded gfx1151 so any target with registered hardware can qualify. This unblocks publishing CDNA assets from CI: after #28, gfx942/gfx950 build, but nothing schedules or qualifies them, and releases gate on qualification.

**What changed**
- `prepare-matrix` derives a `qualify_matrix` from a `QUALIFIED_RUNNERS` map (today `{"gfx1151":"dev_lab"}`; adding hardware for a new target is a one-entry change) and a `qualify_count` gate replaces the `contains(gfx_target,'gfx1151')` gate.
- The qualify job runs per-matrix-target (`GFX` env, runner group from the map); artifact download, extract, report naming, publishing, and the release-attach step are parameterised accordingly.
- Behavior-preserving on every current path: all trigger paths (both crons, default and explicit dispatches, PR) match the old gate. Table below.

**Based on #30 and #32.** This branch carries both (torch 2.12 pairing; tar-before-upload) and assumes their direction: the qualify extract expects the release tar.gz inside the artifact per #32, with #32's one hardcoded gfx1151 error string parameterised. Rebasing after they land drops their commits from this diff.

**Trigger-path parity:**

| # | Trigger | qualify_count | Old gate | New gate |
|---|---------|---------------|----------|----------|
| 1 | schedule (nightly) | 1 | true | true |
| 2 | schedule (omni) | 1 | true | true |
| 3 | dispatch, default targets | 1 | true | true |
| 4 | dispatch, gfx942 only | 0 | false | false |
| 5 | dispatch, gfx1151 | 1 | true | true |
| 6 | dispatch, gfx110X,gfx1150 | 0 | false | false |
| 7 | dispatch, gfx1151,gfx942 (mixed) | 1 | true | true |
| 8 | pull_request | - | false | false |

**Out of scope for this PR:** two questions that only become real once a second target has test hardware - whether a re-run can safely re-publish without duplicating a release, and what should happen when one target passes qualification and another fails in the same run. Today a target with no test box simply skips qualification and releases as before, and this PR keeps that. The omni dedup key still hardcodes gfx1151; that predates this change and is untouched. Naming: the qualify matrix key is `gfx`; `gfx_target` stays the build-side name.

**How tested:** matrix derivation exercised for duplicate, empty, and multi-target inputs (`unique` prevents duplicate legs; an empty map short-circuits before matrix expansion); YAML parses; the rebase onto #30+#32 changed surrounding context only, plus the one error-string parameterisation. The 16-test qualification harness itself has been run against a gfx942 bundle on a rented MI300X, so the CDNA leg this unblocks is exercised up to (not including) the runner registration. Not testable from here: a leg on the dev_lab runner; the parity table above is what we have to verify current gfx1151 behavior is unchanged.
