### PR TITLE
ci: build and qualify on the ephemeral pool from one shared definition

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,11 @@
+# actionlint only knows GitHub's hosted labels, so every self-hosted label in
+# this repo reads as a typo without this file. Declaring them here makes a
+# genuine typo ("strix-hallo") an error again, which is the point.
+self-hosted-runner:
+  labels:
+    # AMD DevLab ephemeral pool: per-job Strix Halo VMs from the orchestrator.
+    # Reached by these specific labels -- the runners are registered to the
+    # repo, so they sit in the repo's Default group and `group:` cannot select
+    # them. The pool also refuses jobs that name only generic labels.
+    - strix-halo
+    - ephemeral

--- a/.github/actions/build-vllm-bundle/action.yml
+++ b/.github/actions/build-vllm-bundle/action.yml
@@ -1,0 +1,753 @@
+# The Ubuntu bundle build, as a composite action so that every pool runs the
+# same steps. Extracted from build-vllm-rocm.yml's build-ubuntu job, which is
+# now one of two callers -- the other is the ephemeral-pool soak leg. Keeping
+# one body is the point: between #30, #32 and #33 these steps changed four
+# times in a week, and a copy would have missed all four.
+#
+# Everything the two callers differ on is an input: which silicon, which
+# artifact name, how long to keep it. The steps themselves do not know which
+# pool they are on.
+name: Build vLLM ROCm bundle
+description: >-
+  Build the portable vLLM + PyTorch ROCm bundle for one gfx target and upload
+  it as a release archive.
+
+inputs:
+  gfx_target:
+    description: GPU target to build (gfx1151, gfx110X, gfx942, ...).
+    required: true
+  artifact_name:
+    description: >-
+      Name to upload the bundle under. Callers outside the release path must
+      pick a name the release jobs never resolve.
+    required: true
+  channel:
+    description: nightly or stable. Selects the CPython ABI and the wheel index.
+    required: true
+  omni:
+    description: When 'true', layer vLLM-Omni onto the bundle.
+    required: false
+    default: 'false'
+  omni_base_vllm_ver:
+    description: Qualified base vLLM version the omni layer builds on.
+    required: false
+    default: ''
+  vllm_ver:
+    description: Nightly vLLM version resolved by detect-nightly.
+    required: false
+    default: ''
+  rocm_stamp:
+    description: ROCm stamp resolved by detect-nightly.
+    required: false
+    default: ''
+  stable_vllm_ver:
+    description: Pinned vLLM version for the stable channel.
+    required: false
+    default: ''
+  retention_days:
+    description: Artifact retention. Soak bundles are not worth a month.
+    required: false
+    default: '30'
+
+outputs:
+  vllm_version:
+    description: vLLM version in the built bundle.
+    value: ${{ steps.set-outputs.outputs.vllm_version }}
+  torch_version:
+    description: torch version in the built bundle.
+    value: ${{ steps.set-outputs.outputs.torch_version }}
+  omni_version:
+    description: vLLM-Omni version, empty on non-omni builds.
+    value: ${{ steps.set-outputs.outputs.omni_version }}
+
+runs:
+  using: "composite"
+  steps:
+    # The step bodies below read these as plain shell variables. Job-level env
+    # from the caller does reach a composite step's process, but relying on
+    # that would make the action depend on what its caller happens to export;
+    # writing them here makes the contract the inputs and nothing else.
+    - name: Export build parameters
+      shell: bash
+      run: |
+        {
+          echo "CHANNEL=${{ inputs.channel }}"
+          echo "OMNI=${{ inputs.omni }}"
+          echo "OMNI_BASE_VLLM_VER=${{ inputs.omni_base_vllm_ver }}"
+        } >> "$GITHUB_ENV"
+
+    - name: Download portable Python (python-build-standalone)
+      shell: bash
+      run: |
+        # Relocatable Python from astral-sh/python-build-standalone — no system
+        # Python/ROCm dependency. The Python version is CHANNEL-DRIVEN because the
+        # two channels' vLLM wheels target different CPython ABIs:
+        #   nightly -> cp314 (AMD's device-all-rdna nightly moved to Python 3.14)
+        #   stable  -> cp313 (AMD's per-gfx stable vLLM is still cp313)
+        # PYVER is exported so every later build step uses the right lib/ path,
+        # and qualify re-derives it from the bundle.
+        if [ "$CHANNEL" = "stable" ]; then
+          PYVER=3.13; PBS_TAG=20260602; PBS_PY=3.13.13
+        else
+          PYVER=3.14; PBS_TAG=20260623; PBS_PY=3.14.6
+        fi
+        PBS_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_TAG}/cpython-${PBS_PY}+${PBS_TAG}-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        echo "channel=$CHANNEL -> Python $PBS_PY (cp${PYVER/./})"
+        echo "Downloading portable Python from $PBS_URL"
+        # Build under the runner's temp dir — no sudo, no shared-box pollution,
+        # and isolated per run (the self-hosted boxes are persistent). VLLM_ROOT
+        # is exported so every later step (and the artifact upload) uses it.
+        ROOT="$RUNNER_TEMP/vllm-build/vllm"
+        rm -rf "$RUNNER_TEMP/vllm-build"
+        mkdir -p "$RUNNER_TEMP/vllm-build"
+        # Extracts to python/ — move to vllm/ so it becomes the release root
+        curl -fsSL "$PBS_URL" | tar -xz -C "$RUNNER_TEMP/vllm-build"
+        mv "$RUNNER_TEMP/vllm-build/python" "$ROOT"
+        "$ROOT/bin/python${PYVER}" --version
+        echo "VLLM_ROOT=$ROOT" >> "$GITHUB_ENV"
+        echo "PYVER=$PYVER" >> "$GITHUB_ENV"
+        echo "Portable Python installed at $ROOT"
+
+    - name: Map GPU target to AMD wheel URLs
+      id: wheel-urls
+      shell: bash
+      run: |
+        target="${{ inputs.gfx_target }}"
+
+        # Map targets to AMD wheel URL suffixes
+        # See: https://rocm.docs.amd.com/en/latest/rocm-for-ai/vllm.html
+        case "$target" in
+          gfx110X) suffix="gfx110X-all" ;;
+          gfx1151) suffix="gfx1151" ;;
+          gfx1150) suffix="gfx1150" ;;
+          gfx120X) suffix="gfx120X-all" ;;
+          # CDNA. These suffixes are the STABLE-channel per-card aisles; the
+          # nightly channel uses AMD's device-all-cdna line instead (resolved in
+          # the install step, which is the only place the channel is known).
+          gfx942) suffix="gfx94X-dcgpu" ;;
+          gfx950) suffix="gfx950-dcgpu" ;;
+          *)
+            echo "ERROR: No AMD pre-built wheels for target: $target"
+            exit 1
+            ;;
+        esac
+
+        echo "torch_index=https://repo.amd.com/rocm/whl/${suffix}/" >> $GITHUB_OUTPUT
+        echo "vllm_index=https://rocm.frameworks.amd.com/whl/${suffix}/" >> $GITHUB_OUTPUT
+        echo "Using PyTorch index: https://repo.amd.com/rocm/whl/${suffix}/"
+        echo "Using vLLM index: https://rocm.frameworks.amd.com/whl/${suffix}/"
+
+    - name: Prepare Python environment
+      shell: bash
+      run: |
+        # No venv needed — install packages directly into the standalone Python.
+        # Pin pip to 24.3.1: it still ships --use-deprecated=legacy-resolver,
+        # which the vLLM install needs. The current resolvelib resolver
+        # RecursionErrors building its result graph on a dependency cycle in
+        # vLLM's closure (resolution.py:_has_route_to_root recurses infinitely,
+        # so no setrecursionlimit saves it); the legacy resolver avoids that path.
+        $VLLM_ROOT/bin/python3 -m pip install "pip==24.3.1"
+        echo "pip: $($VLLM_ROOT/bin/pip --version)"
+        echo "Python: $($VLLM_ROOT/bin/python3 --version)"
+
+    - name: Install vLLM + PyTorch (channel=${{ inputs.channel }})
+      shell: bash
+      run: |
+        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
+        TORCH_INDEX="${{ steps.wheel-urls.outputs.torch_index }}"
+        VLLM_INDEX="${{ steps.wheel-urls.outputs.vllm_index }}"
+
+        # Steer any CMake-based source build (notably onnx, pulled by amd-quark)
+        # at our bundled Python. On cp314/x86_64 some deps have no wheel yet —
+        # onnx 1.19.0 (amd-quark caps onnx<=1.19.0) only ships a cp314 *aarch64*
+        # wheel, so x86_64 falls back to the sdist. onnx's CMake find_package
+        # (Python3) / pybind11 otherwise resolve the box's system python (3.12)
+        # off PATH and emit a cpython-312 ext that pip (running 3.14) can't use.
+        # Putting the bundled interpreter FIRST on PATH makes CMake find 3.14 and
+        # build a cpython-${PYVER} ext (the -D hints alone aren't honored). No-op
+        # when a wheel is used (e.g. stable cp313).
+        export PATH="$VLLM_ROOT/bin:$PATH"
+        export CMAKE_ARGS="${CMAKE_ARGS:-} -DPython3_EXECUTABLE=$VLLM_ROOT/bin/python3 -DPython_EXECUTABLE=$VLLM_ROOT/bin/python3"
+
+        # vLLM's dependency graph trips pip's resolvelib resolver into a
+        # RecursionError (a cycle in its closure), on BOTH channels. No pip flag
+        # controls the recursion depth, so run pip via its entrypoint under a
+        # raised limit; combined with --use-deprecated=legacy-resolver below this
+        # is what lets the install complete. (pip pinned to 24.3.1 in Prepare.)
+        pip_deep() {
+          "$VLLM_ROOT/bin/python3" -c 'import sys; sys.setrecursionlimit(20000); from pip._internal.cli.main import main; sys.exit(main(sys.argv[1:]))' "$@"
+        }
+
+        if [ "$CHANNEL" = "stable" ]; then
+          # STABLE: AMD's per-card matched set — the OLDER one-build-per-gfx
+          # pattern (vLLM at rocm.frameworks.amd.com/whl/<gfx>/, torch at
+          # repo.amd.com/rocm/whl/<gfx>/), NOT the nightly single-RDNA build.
+          # ROCm 7.13 / torch 2.9.1 — a different code-object generation than the
+          # 7.14 nightly, which is the point of this validation run. Same robust
+          # install technique as nightly (legacy resolver + matched-torchvision
+          # repair), pointed at the stable sources.
+          # Pin the cp313 stable vLLM version (don't curl-discover): rocm.
+          # frameworks.amd.com WAF-403s a raw directory-listing GET from the
+          # runner's IP, but pip's PEP503 index access through --extra-index-url
+          # works. Bump this when AMD publishes a newer stable cp313 wheel at
+          # rocm.frameworks.amd.com/whl/gfx1151/vllm/ .
+          VLLM_VER="${{ inputs.stable_vllm_ver || '0.19.1.dev3+rocm7.13.0.g72ed2b398.d20260513' }}"
+          echo "stable: vLLM==$VLLM_VER"
+          # 1. Matched torch from the stable ROCm index (pulls rocm-sdk-* + triton
+          #    at the rocm7.13.0 ABI). The index carries torch 2.9.1 / 2.10.0 /
+          #    2.11.0 all at +rocm7.13.0; vLLM 0.19.1's own code guards pin it to
+          #    torch 2.9.x (>=2.9.0,<2.10.0), so use 2.9.1. NOTE: even this
+          #    code-correct version currently leaves unresolved c10::*[abi:cxx11]
+          #    symbols (tier0 T0.2) — AMD's stable vLLM wheel was built with a
+          #    different _GLIBCXX_USE_CXX11_ABI than its stable torch. That's an
+          #    upstream ABI skew the gate reports; we do not pin around it.
+          $VLLM_ROOT/bin/pip install --index-url "$TORCH_INDEX" \
+            --extra-index-url https://pypi.org/simple/ \
+            "torch==2.9.1+rocm7.13.0"
+          # 2. vLLM by version from the gfx index + PyPI for the ~70 normal deps.
+          #    Same legacy resolver as nightly (the recursion cycle is in vLLM's
+          #    graph regardless of channel); --ignore-requires-python guards any
+          #    amd-quark cp<3.13 cap.
+          ok=0
+          for attempt in 1 2 3; do
+            if pip_deep install --use-deprecated=legacy-resolver --ignore-requires-python \
+                 --extra-index-url "$VLLM_INDEX" \
+                 --extra-index-url "$TORCH_INDEX" \
+                 --extra-index-url https://pypi.org/simple/ \
+                 "vllm==$VLLM_VER"; then ok=1; break; fi
+            echo "::warning::stable vLLM install attempt $attempt failed; retry in $((attempt*10))s"
+            sleep $((attempt * 10))
+          done
+          [ "$ok" = 1 ] || { echo "::error::stable vLLM install failed after 3 attempts"; exit 1; }
+          # 3. Repair: the legacy resolver may have pulled a PyPI torchvision with
+          #    the wrong torch ABI (torchvision::nms unregistered -> import dies).
+          #    Force the matched ROCm build AFTER vLLM. pycountry is an undeclared
+          #    optional transitive (mistral_common). pip check surfaces the rest.
+          $VLLM_ROOT/bin/pip install --index-url "$TORCH_INDEX" \
+            --extra-index-url https://pypi.org/simple/ \
+            "torchvision==0.24.0+rocm7.13.0"
+          $VLLM_ROOT/bin/pip install pycountry
+          $VLLM_ROOT/bin/pip check || echo "::warning::pip check reported conflicts (see above); qualify will gate"
+        else
+          # NIGHTLY: repackage AMD's OFFICIAL nightly. AMD publishes a single
+          # universal RDNA vLLM wheel plus a date-stamped matched torch; we pair
+          # them by the shared ROCm build stamp (rocm7.14.0a<DATE>), so the set
+          # is ABI-consistent by construction — no pinning around mismatches.
+          # AMD publishes the nightly vLLM as TWO separate per-family lines,
+          # device-all-rdna and device-all-cdna, at independent versions. The
+          # line must therefore follow the matrix target, not be hardcoded.
+          # (torch does NOT: whl-multi-arch carries every arch, including
+          # rocm-sdk-device-gfx942/-gfx950, so the torch half is family-agnostic.)
+          case "${{ inputs.gfx_target }}" in
+            gfx942|gfx950) NIGHTLY_SET=device-all-cdna ;;
+            *)             NIGHTLY_SET=device-all-rdna ;;
+          esac
+          NIGHTLY_VLLM=https://rocm.frameworks-nightlies.amd.com/whl/$NIGHTLY_SET
+          NIGHTLY_TORCH=https://rocm.nightlies.amd.com/whl-multi-arch
+          echo "nightly vLLM line: $NIGHTLY_SET"
+          # torch's per-gfx kernels are an extra; map the matrix target to it.
+          case "${{ inputs.gfx_target }}" in
+            gfx1151) DEV=gfx1151 ;;
+            gfx1150) DEV=gfx1150 ;;
+            gfx110X) DEV=gfx1100 ;;
+            gfx120X) DEV=gfx1200 ;;
+            *) DEV="${{ inputs.gfx_target }}" ;;
+          esac
+          # 1. Use the version detect-nightly already resolved (so detect and
+          #    build agree even if AMD publishes a newer one mid-run); else
+          #    discover the newest cp314 wheel from the index.
+          # detect-nightly probes the RDNA line only (it gates the daily cron),
+          # so its version is valid for RDNA targets ONLY. Reusing it for a CDNA
+          # build would pin a version that does not exist on the CDNA line; leave
+          # it empty so the self-discovery below resolves from $NIGHTLY_VLLM.
+          if [ "$NIGHTLY_SET" = "device-all-rdna" ]; then
+            VLLM_VER="${{ inputs.vllm_ver }}"
+            ROCM_STAMP="${{ inputs.rocm_stamp }}"
+          else
+            VLLM_VER=""
+            ROCM_STAMP=""
+          fi
+          if [ -z "$VLLM_VER" ]; then
+            WHL=$(curl -fsSL "$NIGHTLY_VLLM/vllm/" \
+              | grep -oE 'vllm-[0-9][^"]*-cp314-cp314-linux_x86_64\.whl' \
+              | sort | tail -1)
+            VLLM_VER=$(echo "$WHL" | sed -E 's/^vllm-(.*)-cp314-cp314-linux_x86_64\.whl$/\1/' | sed 's/%2B/+/g')
+            ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
+          fi
+          [ -n "$VLLM_VER" ] || { echo "::error::no cp314 nightly vLLM version found"; exit 1; }
+          # Omni builds pin the qualified base (vLLM-Omni 0.23.0rc1 can't ride
+          # the latest nightly — see OMNI_BASE_VLLM_VER). Override the detected
+          # version so build/qualify/release all use the validated base.
+          if [ "$OMNI" = "true" ]; then
+            VLLM_VER="$OMNI_BASE_VLLM_VER"
+            ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
+            echo "omni: pinning base to $VLLM_VER (stamp $ROCM_STAMP)"
+          fi
+          # The torch ABI follows the vLLM WHEEL'S VERSION, so key the pin on
+          # $VLLM_VER (resolved above, after the omni override) — not on the
+          # nightly line. AMD advances its two lines independently: RDNA is on
+          # 0.25.x (torch 2.12 ABI) while CDNA is still on 0.23.1 (torch 2.11
+          # ABI), and whl-multi-arch carries BOTH torch builds at the same ROCm
+          # stamp, so a single global pin resolves and installs cleanly and then
+          # dies in qualify with unresolved torch::Library::_def symbols.
+          # Keying on the line (device-all-cdna -> 2.11) would fix today and
+          # silently re-break the day AMD moves CDNA to 0.25.x; keying on the
+          # version self-corrects. TV_VER moves with TORCH_VER — torchvision
+          # pairs strictly with torch (used by the repair step below) or
+          # torchvision::nms fails to register and `import vllm` dies.
+          case "$VLLM_VER" in
+            0.2[0-4].*) TORCH_VER=2.11.0; TV_VER=0.26.0 ;;
+            *)          TORCH_VER=2.12.0; TV_VER=0.27.0 ;;
+          esac
+          echo "nightly: vLLM==$VLLM_VER"
+          echo "nightly: torch=${TORCH_VER}+${ROCM_STAMP}[device-${DEV}]"
+          # 2. Matched torch + ROCm runtime libs + Triton + per-gfx kernels,
+          #    all resolved at the same ROCm stamp from one index.
+          $VLLM_ROOT/bin/pip install --index-url "$NIGHTLY_TORCH" \
+            --extra-index-url https://pypi.org/simple/ \
+            "torch[device-${DEV}]==${TORCH_VER}+${ROCM_STAMP}"
+          # 3a. Pre-install amd-quark. vLLM pins amd-quark>=0.8.99, but every
+          #    amd-quark >=0.7 on PyPI caps Requires-Python at <3.13 while our
+          #    nightly bundle is cp314. amd-quark is a pure-Python (py3-none-any) wheel —
+          #    the cap is a conservative untested-version guard, not a real ABI
+          #    limit — so install it ALONE with --ignore-requires-python (a tiny
+          #    candidate space). Scoping the flag here, not on the vLLM resolve,
+          #    is deliberate: passed globally it strips the Python filter from
+          #    every dep, ballooning pip's backtracking until it RecursionErrors.
+          #    Once installed and satisfying >=0.8.99, vLLM's resolve accepts it.
+          pip_deep install --ignore-requires-python "amd-quark>=0.8.99"
+          # 3b. The universal vLLM wheel + flash-attn (AMD index) + the rest from
+          #    PyPI. Install BY VERSION through the index (not a hand-built wheel
+          #    URL): the host serves the wheel only at its %2B-encoded path, so a
+          #    direct URL with a literal '+' gets WAF-403'd. Letting pip resolve
+          #    the index href fetches the correctly-encoded URL. vLLM declares no
+          #    torch dep, so the matched torch above is untouched.
+          #    Two flags, both required and complementary:
+          #    --use-deprecated=legacy-resolver: the new resolvelib resolver
+          #    RecursionErrors building its result graph on a cycle in vLLM's
+          #    dependency closure (resolution.py:_has_route_to_root recurses
+          #    without end). The legacy resolver doesn't walk that graph. (pip is
+          #    pinned to 24.3.1 above so this flag still exists.)
+          #    --ignore-requires-python: the legacy resolver re-checks
+          #    requires-python on the already-installed amd-quark (capped <3.13)
+          #    and hard-errors on cp314; the flag makes it accept it. On
+          #    the legacy (first-found, no-backtrack) resolver this can't balloon
+          #    the candidate search the way it would on the new resolver.
+          ok=0
+          for attempt in 1 2 3; do
+            if pip_deep install --use-deprecated=legacy-resolver --ignore-requires-python \
+                 --extra-index-url "$NIGHTLY_VLLM" \
+                 --extra-index-url https://pypi.org/simple/ \
+                 "vllm==$VLLM_VER"; then ok=1; break; fi
+            echo "::warning::vLLM install attempt $attempt failed; retry in $((attempt*10))s"
+            sleep $((attempt * 10))
+          done
+          [ "$ok" = 1 ] || { echo "::error::vLLM install failed after 3 attempts"; exit 1; }
+          # 3c. Repair legacy-resolver over-picks. The legacy resolver takes the
+          #    first-found version and ignores transitive UPPER bounds / ABI, so
+          #    it leaves deps that break vLLM at import (each caught by qualify
+          #    T1.5). Re-assert the correct ones here (small single-package
+          #    resolves — no cycle), then `pip check` surfaces any remaining
+          #    mis-pick in the build log without failing the build (qualify gates).
+          #
+          #    torchvision must match the ROCm torch ABI or its C++ ops
+          #    (torchvision::nms) fail to register and `import vllm` dies. Legacy
+          #    pulled a PyPI torchvision built against a different torch; force the
+          #    matched ROCm build from the nightly index, same rocm stamp.
+          #    TV_VER is set alongside TORCH_VER above — they pair strictly.
+          $VLLM_ROOT/bin/pip install --index-url "$NIGHTLY_TORCH" \
+            --extra-index-url https://pypi.org/simple/ \
+            "torchvision==${TV_VER}+${ROCM_STAMP}"
+          #    transformers needs tokenizers>=0.22.0,<=0.23.0 but legacy pulled
+          #    0.23.1, raising ImportError at import; pin it back into range.
+          $VLLM_ROOT/bin/pip install "tokenizers>=0.22.0,<=0.23.0"
+          #    pycountry: an OPTIONAL transitive nothing declares as a hard dep
+          #    (vLLM -> mistral_common -> pydantic_extra_types.language_code ->
+          #    pycountry), so no resolver installs it, yet mistral_common imports
+          #    it at module load and vllm-server dies without it. Add explicitly.
+          $VLLM_ROOT/bin/pip install pycountry
+          $VLLM_ROOT/bin/pip check || echo "::warning::pip check reported dependency conflicts (see above); qualify will gate"
+        fi
+
+        # Use the AMD pip ROCm SDK amdsmi (_rocm_sdk_core/share/amd_smi) rather
+        # than any amdsmi the wheels bundled.
+        rm -rf $SP/amdsmi $SP/amdsmi-*.dist-info
+
+        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
+          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        export LD_LIBRARY_PATH
+        # Report versions but DO NOT fail the build on a bad combination — a
+        # broken bundle must still be packaged so the qualification gate can
+        # detect and REPORT it. Fixing upstream is never our job.
+        $VLLM_ROOT/bin/python3 -c "
+        import torch; print(f'PyTorch {torch.__version__}')
+        import vllm; print(f'vLLM {vllm.__version__}')
+        " || echo "WARNING: import check failed — qualification will report this"
+
+    - name: Pre-compile Triton HIP utilities (eliminates gcc dependency)
+      shell: bash
+      run: |
+        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
+        TRITON_AMD="$SP/triton/backends/amd"
+        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
+          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        export LD_LIBRARY_PATH
+
+        # Create unversioned symlinks for ROCm libs (pip installs only have versioned .so.N)
+        ROCM_LIB="$SP/_rocm_sdk_core/lib"
+        for lib in "$ROCM_LIB"/*.so.*; do
+          name=$(basename "$lib")
+          link="$ROCM_LIB/${name%%.*}.so"
+          [ ! -e "$link" ] && ln -sf "$name" "$link"
+        done
+        ls -la "$ROCM_LIB/libamdhip64.so" || echo "WARNING: symlink not created"
+
+        # Compile the hip_utils C module with gcc directly and save into the package.
+        # We can't use Triton's compile_module_from_src because it also tries to
+        # dlopen the HIP library, which doesn't work on headless CI.
+        TRITON_AMD="$SP/triton/backends/amd"
+        PYTHON_INC="$VLLM_ROOT/include/python${PYVER}"
+
+        # Generate the C source with the HIP library path baked in
+        $VLLM_ROOT/bin/python3 -c "
+        from pathlib import Path
+        import os
+        dirname = '$TRITON_AMD'
+        src = Path(os.path.join(dirname, 'driver.c')).read_text()
+        # Bake in the relative path that will resolve at runtime via LD_LIBRARY_PATH
+        src = src.replace('/*py_libhip_search_path*/', 'libamdhip64.so', 1)
+        Path('/tmp/hip_utils.c').write_text(src)
+        print('Generated /tmp/hip_utils.c')
+        "
+
+        # Compile with gcc
+        gcc /tmp/hip_utils.c -O3 -shared -fPIC -Wno-psabi \
+          -o "$TRITON_AMD/hip_utils_prebuilt.so" \
+          -I"$TRITON_AMD/include" \
+          -I"$PYTHON_INC"
+        echo "Pre-compiled: $TRITON_AMD/hip_utils_prebuilt.so ($(stat -c%s "$TRITON_AMD/hip_utils_prebuilt.so") bytes)"
+
+        # Patch Triton to load the pre-built .so instead of JIT-compiling
+        DRIVER_PY="$TRITON_AMD/driver.py"
+        sed -i 's|mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|_pso = os.path.join(dirname, "hip_utils_prebuilt.so")\n        if os.path.exists(_pso):\n            import importlib.util as _ilu\n            _sp = _ilu.spec_from_file_location("hip_utils", _pso)\n            mod = _ilu.module_from_spec(_sp)\n            _sp.loader.exec_module(mod)\n        else:\n            mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|' "$DRIVER_PY"
+        $VLLM_ROOT/bin/python3 -c "import ast; ast.parse(open('$DRIVER_PY').read()); print('Patched driver.py — syntax OK')"
+
+    - name: Create launcher script
+      shell: bash
+      run: |
+        cat > $VLLM_ROOT/bin/vllm-server << 'LAUNCHER_EOF'
+        #!/bin/bash
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        VENV_DIR="$(dirname "$SCRIPT_DIR")"
+        # Glob the bundled python3.* dir so the launcher is Python-version-agnostic
+        # (the bundle is cp313 or cp314 depending on channel).
+        SP="$(echo "$VENV_DIR"/lib/python3.*/site-packages)"
+        # Add all bundled ROCm library paths
+        for libdir in "$SP"/_rocm_sdk_*/lib "$SP"/torch/lib; do
+        [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        # Also add LLVM lib for the bundled clang
+        LD_LIBRARY_PATH="$SP/_rocm_sdk_core/lib/llvm/lib:${LD_LIBRARY_PATH}"
+        export LD_LIBRARY_PATH
+        export PYTHONPATH="$SP/_rocm_sdk_core/share/amd_smi:${PYTHONPATH:-}"
+        export FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
+        # Use bundled clang for Triton JIT (no system gcc needed)
+        CLANG="$SP/_rocm_sdk_core/lib/llvm/bin/clang"
+        [ -f "$CLANG" ] && chmod +x "$CLANG" "$CLANG"-* 2>/dev/null
+        export CC="$CLANG"
+        exec "$SCRIPT_DIR/python3" -m vllm.entrypoints.openai.api_server "$@"
+        LAUNCHER_EOF
+
+        # Remove YAML indentation from heredoc
+        sed -i 's/^        //' $VLLM_ROOT/bin/vllm-server
+        chmod +x $VLLM_ROOT/bin/vllm-server
+        echo "Launcher script:"
+        cat $VLLM_ROOT/bin/vllm-server
+
+    - name: Strip unnecessary files to reduce size
+      shell: bash
+      run: |
+        cd $VLLM_ROOT
+        echo "=== Size before cleanup ==="
+        du -sh .
+
+        SP="lib/python${PYVER}/site-packages"
+
+        # Remove pip/wheel (keep setuptools — torch.utils.cpp_extension needs it)
+        rm -rf $SP/pip* $SP/wheel* 2>/dev/null || true
+
+        # Remove __pycache__ and .pyc
+        find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+        find . -name "*.pyc" -delete 2>/dev/null || true
+
+        # Remove test/benchmark dirs (but NOT torch.testing — it's imported at runtime)
+        rm -rf $SP/torch/test $SP/torch/benchmarks 2>/dev/null || true
+
+        # Remove packages not needed for inference serving (~500MB)
+        rm -rf $SP/pyarrow* $SP/opencv* $SP/cv2* 2>/dev/null || true
+        rm -rf $SP/onnx* $SP/pandas* $SP/plotly* 2>/dev/null || true
+        rm -rf $SP/datasets* $SP/evaluate* $SP/peft* $SP/timm* 2>/dev/null || true
+        rm -rf $SP/boto3* $SP/botocore* $SP/s3transfer* 2>/dev/null || true
+        rm -rf $SP/azure* $SP/google_cloud* $SP/google_auth* $SP/msal* 2>/dev/null || true
+        rm -rf $SP/tensorizer* $SP/runai* 2>/dev/null || true
+        rm -rf $SP/aiter_meta* 2>/dev/null || true
+
+        # Trim LLVM toolchain: keep only clang + its libs (~350MB saved)
+        LLVM="$SP/_rocm_sdk_core/lib/llvm"
+        # Keep the clang driver and its versioned binary (clang-NN). The LLVM
+        # major tracks the ROCm release (clang-22 on 7.13, clang-23 on 7.14);
+        # hardcoding clang-22 would delete the real compiler on newer ROCm and
+        # break Triton's runtime JIT. Match clang-* so it survives any version.
+        find "$LLVM/bin" -type f ! -name "clang" ! -name "clang-*" -delete 2>/dev/null || true
+        find "$LLVM/bin" -type l ! -name "clang" -delete 2>/dev/null || true
+        # Keep only libs that clang needs (libclang-cpp, libLLVM, rocm_sysdeps)
+        find "$LLVM/lib" -name "*.so*" \
+          ! -name "libclang-cpp*" \
+          ! -name "libLLVM*" \
+          -delete 2>/dev/null || true
+        rm -rf "$LLVM/lib/clang/"*/include/cuda_wrappers 2>/dev/null || true
+
+        # Trim ROCm SDK bin/ (Python wrapper scripts, not needed)
+        rm -rf "$SP/_rocm_sdk_core/bin" 2>/dev/null || true
+
+        # Remove Python stdlib we don't need
+        rm -rf lib/python${PYVER}/test lib/python${PYVER}/tkinter lib/python${PYVER}/idlelib 2>/dev/null || true
+        rm -rf lib/python${PYVER}/turtledemo lib/python${PYVER}/ensurepip 2>/dev/null || true
+        # Keep include/ — Triton JIT needs Python.h headers
+
+        # Ensure bundled clang is executable (permissions lost during tar)
+        chmod +x "$LLVM/bin/clang"* 2>/dev/null || true
+
+        # NOTE: Do NOT strip .so files — AMD ROCm wheels use special ELF
+        # alignment that strip corrupts, and numpy/scipy also break.
+
+        echo "=== Size after cleanup ==="
+        du -sh .
+        echo ""
+        echo "Top consumers:"
+        du -sh $SP/torch/ $SP/vllm/ $SP/_rocm_sdk_core/ $SP/aiter/ $SP/triton/ 2>/dev/null || true
+
+    - name: Layer vLLM-Omni onto the bundle (omni builds only)
+      # MUST run AFTER the Strip step: Strip deletes opencv/onnx/peft/timm (and
+      # pip) — exactly the deps the omni layer reinstalls. build_omni_layer.sh
+      # re-bootstraps pip and pulls vllm-omni + its runtime/multimodal deps + an
+      # ABI-matched torchaudio. torchaudio must come from the SAME ROCm index as
+      # the bundled torch: per-gfx stable index on the stable channel, AMD's
+      # multi-arch nightly index on nightly.
+      if: ${{ inputs.omni == 'true' }}
+      env:
+        TORCH_INDEX: ${{ inputs.channel == 'stable' && steps.wheel-urls.outputs.torch_index || 'https://rocm.nightlies.amd.com/whl-multi-arch' }}
+      shell: bash
+      run: |
+        bash scripts/build_omni_layer.sh
+
+    - name: Make console-script shebangs relocatable
+      # pip records the build-time interpreter path in every console script it
+      # generates, so on a consumer machine execve() fails and reports the
+      # SCRIPT as missing rather than the interpreter. Rewrite the shebang to
+      # resolve the interpreter next to the script. The replacement is valid sh
+      # and a no-op string expression in Python, so the scripts still parse.
+      # Matches ANY absolute python-interpreter shebang (not just $VLLM_ROOT/bin:
+      # wheels can record foreign build prefixes like /opt/vllm), including
+      # distlib's quoted form (#!"/path with spaces/python3") and interpreter
+      # options (#!/path/python3 -u), which are re-emitted after the resolved
+      # interpreter. A PEP 263 coding cookie on line 2 is carried forward so it
+      # stays within the two lines Python scans. __doc__ is reset to None so the
+      # trampoline text never leaks into argparse(description=__doc__).
+      # Completeness gate: after the pass, re-scan and FAIL if any absolute
+      # python shebang remains ("no build-time shebangs remain", not "at least
+      # one was fixed"), then compile() every rewritten file as a parse check.
+      shell: bash
+      run: |
+        : "${VLLM_ROOT:?VLLM_ROOT is unset -- refusing to guess the bundle path}"
+        python3 - "$VLLM_ROOT/bin" <<'PYEOF'
+        import os, re, stat, sys
+        from pathlib import Path
+
+        bindir = Path(sys.argv[1])
+        name_re = re.compile(rb"^python[0-9]*(\.[0-9]+)*$")  # not python3-config
+        coding_re = re.compile(rb"^[ \t\f]*#.*?coding[:=][ \t]*[-_.a-zA-Z0-9]+")
+
+        def parse_shebang(first):
+            """(interpreter, [options]) for an absolute-path shebang, else (None, None)."""
+            body = first[2:].rstrip(b"\r").strip()
+            if body.startswith(b'"'):
+                end = body.find(b'"', 1)
+                if end < 0:
+                    return None, None
+                return body[1:end], body[end + 1:].split()
+            fields = body.split()
+            if not fields or not fields[0].startswith(b"/"):
+                return None, None
+            return fields[0], fields[1:]
+
+        def python_shebang(first):
+            interp, opts = parse_shebang(first)
+            if interp is None or not name_re.match(os.path.basename(interp)):
+                return None, None
+            return interp, opts
+
+        fixed = []
+        for path in sorted(bindir.iterdir()):
+            if not path.is_file() or path.is_symlink():
+                continue
+            first, _, rest = path.read_bytes().partition(b"\n")
+            if not first.startswith(b"#!"):
+                continue
+            interp, opts = python_shebang(first)
+            if interp is None:
+                continue
+            name = os.path.basename(interp)
+            cookie = b""
+            rest_first, _, rest_tail = rest.partition(b"\n")
+            if coding_re.match(rest_first):
+                cookie = rest_first + b"\n"
+                rest = rest_tail
+            optstr = b" " + b" ".join(opts) if opts else b""
+            # A statement before `from __future__` is a SyntaxError (the polyglot
+            # DOCSTRING before it is legal) -- caught by the compile() gate on the
+            # real bundle (numba). Those few scripts keep the trampoline as
+            # __doc__; everything else gets None.
+            doc_reset = b"" if b"from __future__" in rest else b"__doc__ = None\n"
+            mode = path.stat().st_mode
+            path.write_bytes(
+                b"#!/bin/sh\n" + cookie
+                + b"'''exec' \"$(dirname \"$(readlink -f \"$0\")\")/" + name + b"\""
+                + optstr + b" \"$0\" \"$@\"\n"
+                b"' '''\n"
+                + doc_reset + rest
+            )
+            os.chmod(path, stat.S_IMODE(mode))
+            fixed.append(path)
+
+        print("rewrote %d console-script shebangs" % len(fixed))
+        if not fixed:
+            sys.exit("error: rewrote nothing -- refusing to ship an unchecked bundle")
+
+        leftover = []
+        for path in sorted(bindir.iterdir()):
+            if not path.is_file() or path.is_symlink():
+                continue
+            first = path.read_bytes().partition(b"\n")[0]
+            if first.startswith(b"#!") and python_shebang(first)[0] is not None:
+                leftover.append(path.name)
+        if leftover:
+            sys.exit("error: build-time python shebangs remain after the pass: %s"
+                     % ", ".join(leftover))
+
+        for path in fixed:
+            try:
+                compile(path.read_bytes(), str(path), "exec")
+            except SyntaxError as e:
+                sys.exit("error: rewritten script no longer parses: %s: %s" % (path, e))
+        print("verified: 0 absolute python shebangs remain; %d rewritten scripts compile"
+              % len(fixed))
+        PYEOF
+
+    - name: Verify bundled environment works
+      shell: bash
+      run: |
+        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
+        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
+          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        export LD_LIBRARY_PATH
+
+        $VLLM_ROOT/bin/python3 -c "import vllm; print(f'vLLM {vllm.__version__} OK')"
+        $VLLM_ROOT/bin/python3 -c "import torch; print(f'PyTorch {torch.__version__} OK')"
+        $VLLM_ROOT/bin/python3 -c "
+        # Verify native extensions exist (they load only with GPU present)
+        import os, pathlib
+        sp = pathlib.Path('$SP/vllm')
+        for ext in ['_C.abi3.so', '_rocm_C.abi3.so']:
+            p = sp / ext
+            assert p.exists(), f'Missing {ext}'
+            print(f'{ext}: {p.stat().st_size // 1048576} MB')
+        print('Native extensions verified')
+        "
+        bash -n $VLLM_ROOT/bin/vllm-server
+        # Execute one REWRITTEN console script for real -- python3 -c above runs
+        # the interpreter directly and bash -n checks the untouched wrapper, so
+        # neither would notice all ~113 rewritten scripts being dead. This
+        # exercises the sh trampoline end-to-end (a full sh -n cannot: sh parses
+        # a polyglot past the exec line into the Python body).
+        #
+        # Pick the probe at runtime rather than hardcoding a name: the Strip step
+        # removes $SP/pip* (and build_omni_layer.sh re-strips it), so bin/pip is a
+        # DANGLING console script -- probing it fails with ModuleNotFoundError on
+        # every build, which says nothing about the trampoline. Candidates below
+        # are ordered by how certain their module is to survive the strip; torch
+        # and vllm are the bundle's reason to exist and are never trimmed.
+        probe=""
+        for cand in torchrun vllm isympy f2py normalizer; do
+          [ -x "$VLLM_ROOT/bin/$cand" ] || continue
+          # Confirm the module behind it survived the strip before relying on it.
+          if "$VLLM_ROOT/bin/$cand" --help >/dev/null 2>&1; then probe="$cand"; break; fi
+        done
+        if [ -z "$probe" ]; then
+          echo "::error::no rewritten console script could be executed -- the sh trampoline may be broken"
+          ls -1 "$VLLM_ROOT/bin" | head -40
+          exit 1
+        fi
+        echo "trampoline probe OK: bin/$probe launched the bundled interpreter"
+        echo "All sanity checks passed"
+
+    - name: Report final size
+      shell: bash
+      run: |
+        echo "=== Final artifact ==="
+        du -sh $VLLM_ROOT/
+        echo ""
+        du -sh $VLLM_ROOT/*/ 2>/dev/null
+
+    - name: Create release archive
+      shell: bash
+      run: |
+        # tar.gz preserves the ROCm symlinks (upload-artifact's zip expands each
+        # symlink into a full copy of its target, bloating the artifact). tar
+        # also keeps the hidden per-gfx GPU code-object dirs (torch/.kpack/,
+        # _rocm_sdk_*/.kpack/, .devel_links/) that ROCm wheels ship, so
+        # include-hidden-files is no longer needed.
+        ARCHIVE="$RUNNER_TEMP/vllm-ubuntu-rocm-${{ inputs.gfx_target }}-x64.tar.gz"
+        tar -czf "$ARCHIVE" -C "$VLLM_ROOT" .
+        echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+        echo "Created $(du -h "$ARCHIVE" | cut -f1) archive"
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        # Upload the intermediate tar.gz (not the raw bundle), so the artifact
+        # preserves symlinks and the hidden per-gfx code-object dirs on download.
+        path: ${{ env.ARCHIVE }}
+        retention-days: ${{ inputs.retention_days }}
+        compression-level: 6
+
+    - name: Set job outputs
+      id: set-outputs
+      shell: bash
+      run: |
+        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
+        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
+          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        export LD_LIBRARY_PATH
+
+        vllm_ver=$($VLLM_ROOT/bin/python3 -c "import vllm; print(vllm.__version__)")
+        torch_ver=$($VLLM_ROOT/bin/python3 -c "import torch; print(torch.__version__)")
+        echo "vllm_version=$vllm_ver" >> $GITHUB_OUTPUT
+        echo "torch_version=$torch_ver" >> $GITHUB_OUTPUT
+        # Empty on non-omni builds. Read from dist-info (no heavy import) so the
+        # create-release tag can distinguish vllm-omni* artifacts.
+        omni_ver=$(ls -d "$SP"/vllm_omni-*.dist-info 2>/dev/null | head -1 \
+          | sed -E 's#.*/vllm_omni-(.*)\.dist-info#\1#')
+        echo "omni_version=$omni_ver" >> $GITHUB_OUTPUT
+
+    - name: Clean up
+      if: always()
+      shell: bash
+      run: |
+        # No sudo — it's under the runner's temp dir. Free the box for the next run.
+        rm -rf "$RUNNER_TEMP/vllm-build" || true

--- a/.github/actions/qualify-vllm-bundle/action.yml
+++ b/.github/actions/qualify-vllm-bundle/action.yml
@@ -1,0 +1,219 @@
+# The 16-test qualification harness, as a composite action so that every pool
+# runs the same tests. Extracted from build-vllm-rocm.yml's qualify job; see
+# the build action for why there is one body rather than one per pool.
+#
+# tier0 static (6) + tier1 hardware smoke (5) + tier2 functional inference (5),
+# aggregated into a qualification report and a promotion decision.
+name: Qualify vLLM ROCm bundle
+description: >-
+  Download a built bundle, run the 16-test qualification harness against real
+  hardware, and upload the report.
+
+inputs:
+  gfx:
+    description: GPU target being qualified.
+    required: true
+  build_artifact:
+    description: Name of the bundle artifact to qualify.
+    required: true
+  report_artifact_name:
+    description: >-
+      Name to upload the qualification report under. publish-qualification
+      globs `qualification-*`, so a caller whose results must stay out of the
+      published feed has to pick a name outside that glob.
+    required: true
+  channel:
+    description: nightly or stable.
+    required: true
+  omni:
+    description: When 'true', run the omni tier as well.
+    required: false
+    default: 'false'
+  vllm_version:
+    description: vLLM version from the build, used to tag the report.
+    required: false
+    default: ''
+  omni_version:
+    description: vLLM-Omni version from the build, empty on non-omni runs.
+    required: false
+    default: ''
+
+outputs:
+  result:
+    description: Promotion decision emitted by the harness.
+    value: ${{ steps.qual.outputs.result }}
+
+runs:
+  using: "composite"
+  steps:
+    # See the build action: the step bodies read these as shell variables, and
+    # the action's contract should be its inputs rather than its caller's env.
+    - name: Export qualification parameters
+      shell: bash
+      run: |
+        {
+          echo "GFX=${{ inputs.gfx }}"
+          echo "CHANNEL=${{ inputs.channel }}"
+          echo "OMNI=${{ inputs.omni }}"
+          echo "BUILD_ARTIFACT=${{ inputs.build_artifact }}"
+        } >> "$GITHUB_ENV"
+
+    - name: Download ${{ inputs.gfx }} artifact
+      env:
+        GH_TOKEN: ${{ github.token }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        WORK="${{ runner.temp }}/vllm-qual"
+        DEST="$WORK/vllm"
+        ZIP="$WORK/artifact.zip"
+        mkdir -p "$DEST"
+        echo "=== Disk before download ==="; df -h "$WORK" || true
+
+        # The build artifact is ~3.3 GB (extracts to ~11 GB). actions/download-artifact@v4
+        # is unreliable for artifacts this size on self-hosted runners, so pull the
+        # artifact zip directly with curl (streams to disk, resumable), unzip it to
+        # recover the release tar.gz, then untar it below.
+        # Resolve the artifact id via the REST API with curl + python3 — the box
+        # does not have the gh CLI installed.
+        ART_ID=$(curl -fsSL \
+                   -H "Authorization: Bearer $GH_TOKEN" \
+                   -H "Accept: application/vnd.github+json" \
+                   "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+                 | python3 -c "import sys,json,os; print(next((a['id'] for a in json.load(sys.stdin)['artifacts'] if a['name']==os.environ['BUILD_ARTIFACT']), ''))")
+        [ -n "$ART_ID" ] || { echo "::error::${GFX} artifact not found for this run"; exit 1; }
+        echo "Artifact id: $ART_ID"
+
+        avail_gb=$(df -BG --output=avail "$WORK" | tail -1 | tr -dc '0-9')
+        echo "Available space: ${avail_gb} GB"
+        if [ "${avail_gb:-0}" -lt 15 ]; then
+          echo "::error::Only ${avail_gb} GB free on the runner; need ~15 GB for the 11 GB build."
+          exit 1
+        fi
+
+        ok=0
+        for attempt in 1 2 3; do
+          echo "=== curl attempt $attempt ==="
+          if curl -fL --retry 5 --retry-delay 10 --retry-all-errors -C - \
+                  -H "Authorization: Bearer $GH_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  -o "$ZIP" \
+                  "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${ART_ID}/zip"; then
+            ok=1; break
+          fi
+          echo "attempt $attempt failed; retrying in 15s"; sleep 15
+        done
+        [ "$ok" = "1" ] || { echo "::error::artifact zip download failed after 3 attempts"; df -h "$WORK" || true; exit 1; }
+        echo "Downloaded zip: $(du -h "$ZIP" | cut -f1)"
+
+        echo "=== Extracting ==="
+        # The artifact now holds the release tar.gz (not the raw bundle contents):
+        # unzip it, then untar so $DEST is the bundle root (bin/, lib/, ...).
+        # tar.gz preserves the ROCm symlinks the zip previously dropped.
+        if command -v unzip >/dev/null 2>&1; then
+          unzip -q -o "$ZIP" -d "$WORK/raw"
+        else
+          python3 -m zipfile -e "$ZIP" "$WORK/raw"
+        fi
+        rm -f "$ZIP"   # reclaim space immediately
+        TARBALL=$(find "$WORK/raw" -name '*.tar.gz' | head -n1)
+        [ -n "$TARBALL" ] || { echo "::error::no release archive in ${GFX} artifact"; exit 1; }
+        tar -xzf "$TARBALL" -C "$DEST"
+        rm -rf "$WORK/raw"
+        echo "Extracted $(du -sh "$DEST" | cut -f1) to $DEST"
+        echo "=== Disk after extract ==="; df -h "$WORK" || true
+
+    - name: Restore permissions and ROCm symlinks
+      shell: bash
+      run: |
+        # The artifact zip wraps a single tar.gz whose tar -xzf restores modes
+        # and the unversioned .so symlinks, so this is a defensive backstop
+        # (older raw-file artifacts lost +x), not a required repair.
+        ROOT="${{ runner.temp }}/vllm-qual/vllm"
+        # The bundle's Python version is channel-dependent (cp313 stable / cp314
+        # nightly); glob it rather than hardcode.
+        SP="$(echo "$ROOT"/lib/python3.*/site-packages)"
+        chmod +x "$ROOT/bin/"* 2>/dev/null || true
+        chmod +x "$SP/_rocm_sdk_core/lib/llvm/bin/"clang* 2>/dev/null || true
+        ROCM_LIB="$SP/_rocm_sdk_core/lib"
+        for lib in "$ROCM_LIB"/*.so.*; do
+          [ -e "$lib" ] || continue
+          name=$(basename "$lib"); link="$ROCM_LIB/${name%%.*}.so"
+          # Use `if` (not `&&`) so a pre-existing symlink doesn't leave the loop
+          # with exit 1 and trip `set -e`. The artifact preserves these symlinks,
+          # so this is now mostly a defensive no-op.
+          if [ ! -e "$link" ]; then ln -sf "$name" "$link"; fi
+        done
+
+    - name: Run 16-test qualification (tier0 + tier1 + tier2)
+      id: qual
+      shell: bash
+      run: |
+        WORK="${{ runner.temp }}/vllm-qual"
+        ROOT="$WORK/vllm"
+        PY="$ROOT/bin/python3"
+        FRAG="$WORK/fragments"; mkdir -p "$FRAG"
+        Q="$GITHUB_WORKSPACE/scripts/qualify"
+        TAG="vllm${{ inputs.vllm_version }}-${GFX}"
+        # Omni builds qualify the omni serving path and record an omni candidate tag.
+        if [ "$OMNI" = "true" ]; then
+          TAG="vllm-omni${{ inputs.omni_version }}-${GFX}"
+        fi
+
+        # The tiers are run WITHOUT --fail-on-error so all 16 tests execute and
+        # emit a JSON fragment even when one fails; `aggregate --fail-on-no-promote`
+        # is the single gate that decides pass/fail for the whole job.
+        echo "::group::Tier 0 — static bundle verification (T0.1–T0.6)"
+        "$PY" "$Q/tier0_static.py"   --bundle-root "$ROOT" --gfx-target "$GFX" \
+            --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier0-report.json" || true
+        echo "::endgroup::"
+
+        echo "::group::Tier 1 — hardware smoke (T1.1–T1.5)"
+        "$PY" "$Q/tier1_smoke.py"    --bundle-root "$ROOT" --gfx-target "$GFX" \
+            --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier1-report.json" || true
+        echo "::endgroup::"
+
+        # Tier 2 functional inference. Omni bundles run the omni serving path
+        # (vllm-omni-server + single-GPU deploy config) instead of plain vLLM;
+        # both emit a `tier2` fragment so the aggregate require-tiers rule is
+        # identical. The two are mutually exclusive per run.
+        if [ "$OMNI" = "true" ]; then
+          echo "::group::Tier 2 (omni) — functional inference via vllm-omni-server"
+          "$PY" "$Q/tier2_omni.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
+              --channel "$CHANNEL" --candidate-tag "$TAG" --logs-dir "$FRAG" \
+              --output "$FRAG/tier2-report.json" || true
+          echo "::endgroup::"
+        else
+          echo "::group::Tier 2 — functional inference (T2.1–T2.5)"
+          "$PY" "$Q/tier2_inference.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
+              --channel "$CHANNEL" --candidate-tag "$TAG" \
+              --model Qwen/Qwen2.5-0.5B-Instruct --logs-dir "$FRAG" \
+              --output "$FRAG/tier2-report.json" || true
+          echo "::endgroup::"
+        fi
+
+        echo "=== Aggregate fragments → qualification report (gates the job) ==="
+        "$PY" "$Q/aggregate.py" --fragments-dir "$FRAG" --gfx-target "$GFX" \
+            --channel "$CHANNEL" --candidate-tag "$TAG" \
+            --require-tiers tier0,tier1,tier2 --hardware-validated \
+            --output "$FRAG/qualification-report.json" \
+            --fail-on-no-promote
+
+    - name: Upload qualification report and fragments
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.report_artifact_name }}
+        path: |
+          ${{ runner.temp }}/vllm-qual/fragments/*.json
+          ${{ runner.temp }}/vllm-qual/fragments/*.log
+        if-no-files-found: warn
+
+    - name: Tear down and clean up
+      if: always()
+      shell: bash
+      run: |
+        # Free the GPU on this persistent runner no matter how the harness ended.
+        WORK="${{ runner.temp }}/vllm-qual"
+        pkill -9 -f "vllm.entrypoints.openai.api_server" 2>/dev/null || true
+        rm -rf "$WORK" || true

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -939,6 +939,760 @@ jobs:
         pkill -9 -f "vllm.entrypoints.openai.api_server" 2>/dev/null || true
         rm -rf "$WORK" || true
 
+  # ==========================================================================
+  # The same build and the same qualification, on the AMD DevLab ephemeral pool
+  #
+  # Copies of build-ubuntu and qualify pinned to the ephemeral pool -- which
+  # provisions a Strix Halo (gfx1151) VM per job and destroys it afterwards --
+  # and chained to each other rather than into the release path. They run
+  # alongside the dev_lab jobs, never in place of them.
+  #
+  # Two things differ beyond runs-on, both deliberate:
+  #
+  #   gfx1151 only. That is the silicon this pool has. The other targets in the
+  #   release matrix have no ephemeral hardware to build for.
+  #
+  #   No dedup gate. The release path skips a build when detect-nightly says
+  #   the wheel has already been qualified. That is right for a shared box and
+  #   wrong for a pool being soaked -- it would idle these jobs on every day
+  #   AMD does not publish, which is most days.
+  #
+  # Nothing in the release path can see them: they need each other and not
+  # build-ubuntu, publish-qualification still needs qualify, create-release is
+  # still gated on qualify, and both artifacts are prefixed ephemeral- so they
+  # fall outside every name and pattern the release jobs resolve. Ephemeral
+  # artifacts keep 7 days rather than 30 -- an 11 GB bundle rebuilt daily is
+  # not worth a month of storage when nothing downstream reads it.
+  #
+  # The trade: this chain builds its own bundle, so the comparison is
+  # whole-path against whole-path rather than two runners over one artifact.
+  # That is the price of exercising the build here too, and the build is the
+  # half that would otherwise never run on this pool at all.
+  #
+  # When the dev_lab box is decommissioned: delete build-ubuntu and qualify,
+  # drop the -ephemeral suffixes, restore the dedup gate and the full matrix,
+  # and repoint publish-qualification and create-release. To call the trial
+  # off: delete these two jobs.
+  # ==========================================================================
+  build-ubuntu-ephemeral:
+    # Target the dev_lab runner GROUP explicitly, not just labels. The org's
+    # Default group is visibility:all, so a bare [self-hosted, Linux] also
+    # matches Linux boxes in other groups (stx / sjlab / Default) the repo can
+    # see — runs landed on a non-dev_lab box. `group: dev_lab` + the Linux label
+    # selects only the dev_lab Linux box (currently ta-devlab-halo-03) with no
+    # name-pin, so it survives re-image/rename as long as the box stays in the
+    # group. AMD's frameworks-nightlies host allowlists these boxes' egress but
+    # 403s GitHub-hosted runner IPs, so the nightly vLLM wheel must be fetched
+    # here. Build needs only network + pip (no GPU); it shares the box with
+    # qualify, which runs after via `needs`.
+    runs-on: [self-hosted, Linux, strix-halo, ephemeral]
+    continue-on-error: true
+    needs: [prepare-matrix, detect-nightly]
+    # Deliberately NOT gated on detect-nightly's dedup, unlike the release
+    # build above. Skipping when the nightly has already been qualified is
+    # right for a shared box and wrong for a pool being soaked: it would
+    # idle this job on every day AMD does not publish, which is most days.
+    # This runs on every schedule and every dispatch. PRs stay excluded --
+    # an 11 GB build per push is not what anyone is asking for.
+    if: github.event_name != 'pull_request'
+    strategy:
+      # Strix Halo is what this pool is; the other release targets have no
+      # ephemeral hardware to build for.
+      matrix:
+        gfx_target: [gfx1151]
+      fail-fast: false
+    outputs:
+      vllm_version: ${{ steps.set-outputs.outputs.vllm_version }}
+      torch_version: ${{ steps.set-outputs.outputs.torch_version }}
+      # Non-empty only on omni builds; create-release uses it to pick the tag.
+      omni_version: ${{ steps.set-outputs.outputs.omni_version }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Download portable Python (python-build-standalone)
+      run: |
+        # Relocatable Python from astral-sh/python-build-standalone — no system
+        # Python/ROCm dependency. The Python version is CHANNEL-DRIVEN because the
+        # two channels' vLLM wheels target different CPython ABIs:
+        #   nightly -> cp314 (AMD's device-all-rdna nightly moved to Python 3.14)
+        #   stable  -> cp313 (AMD's per-gfx stable vLLM is still cp313)
+        # PYVER is exported so every later build step uses the right lib/ path,
+        # and qualify re-derives it from the bundle.
+        if [ "$CHANNEL" = "stable" ]; then
+          PYVER=3.13; PBS_TAG=20260602; PBS_PY=3.13.13
+        else
+          PYVER=3.14; PBS_TAG=20260623; PBS_PY=3.14.6
+        fi
+        PBS_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_TAG}/cpython-${PBS_PY}+${PBS_TAG}-x86_64-unknown-linux-gnu-install_only.tar.gz"
+        echo "channel=$CHANNEL -> Python $PBS_PY (cp${PYVER/./})"
+        echo "Downloading portable Python from $PBS_URL"
+        # Build under the runner's temp dir — no sudo, no shared-box pollution,
+        # and isolated per run (the self-hosted boxes are persistent). VLLM_ROOT
+        # is exported so every later step (and the artifact upload) uses it.
+        ROOT="$RUNNER_TEMP/vllm-build/vllm"
+        rm -rf "$RUNNER_TEMP/vllm-build"
+        mkdir -p "$RUNNER_TEMP/vllm-build"
+        # Extracts to python/ — move to vllm/ so it becomes the release root
+        curl -fsSL "$PBS_URL" | tar -xz -C "$RUNNER_TEMP/vllm-build"
+        mv "$RUNNER_TEMP/vllm-build/python" "$ROOT"
+        "$ROOT/bin/python${PYVER}" --version
+        echo "VLLM_ROOT=$ROOT" >> "$GITHUB_ENV"
+        echo "PYVER=$PYVER" >> "$GITHUB_ENV"
+        echo "Portable Python installed at $ROOT"
+
+    - name: Map GPU target to AMD wheel URLs
+      id: wheel-urls
+      run: |
+        target="${{ matrix.gfx_target }}"
+
+        # Map targets to AMD wheel URL suffixes
+        # See: https://rocm.docs.amd.com/en/latest/rocm-for-ai/vllm.html
+        case "$target" in
+          gfx110X) suffix="gfx110X-all" ;;
+          gfx1151) suffix="gfx1151" ;;
+          gfx1150) suffix="gfx1150" ;;
+          gfx120X) suffix="gfx120X-all" ;;
+          # CDNA. These suffixes are the STABLE-channel per-card aisles; the
+          # nightly channel uses AMD's device-all-cdna line instead (resolved in
+          # the install step, which is the only place the channel is known).
+          gfx942) suffix="gfx94X-dcgpu" ;;
+          gfx950) suffix="gfx950-dcgpu" ;;
+          *)
+            echo "ERROR: No AMD pre-built wheels for target: $target"
+            exit 1
+            ;;
+        esac
+
+        echo "torch_index=https://repo.amd.com/rocm/whl/${suffix}/" >> $GITHUB_OUTPUT
+        echo "vllm_index=https://rocm.frameworks.amd.com/whl/${suffix}/" >> $GITHUB_OUTPUT
+        echo "Using PyTorch index: https://repo.amd.com/rocm/whl/${suffix}/"
+        echo "Using vLLM index: https://rocm.frameworks.amd.com/whl/${suffix}/"
+
+    - name: Prepare Python environment
+      run: |
+        # No venv needed — install packages directly into the standalone Python.
+        # Pin pip to 24.3.1: it still ships --use-deprecated=legacy-resolver,
+        # which the vLLM install needs. The current resolvelib resolver
+        # RecursionErrors building its result graph on a dependency cycle in
+        # vLLM's closure (resolution.py:_has_route_to_root recurses infinitely,
+        # so no setrecursionlimit saves it); the legacy resolver avoids that path.
+        $VLLM_ROOT/bin/python3 -m pip install "pip==24.3.1"
+        echo "pip: $($VLLM_ROOT/bin/pip --version)"
+        echo "Python: $($VLLM_ROOT/bin/python3 --version)"
+
+    - name: Install vLLM + PyTorch (channel=${{ env.CHANNEL }})
+      run: |
+        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
+        TORCH_INDEX="${{ steps.wheel-urls.outputs.torch_index }}"
+        VLLM_INDEX="${{ steps.wheel-urls.outputs.vllm_index }}"
+
+        # Steer any CMake-based source build (notably onnx, pulled by amd-quark)
+        # at our bundled Python. On cp314/x86_64 some deps have no wheel yet —
+        # onnx 1.19.0 (amd-quark caps onnx<=1.19.0) only ships a cp314 *aarch64*
+        # wheel, so x86_64 falls back to the sdist. onnx's CMake find_package
+        # (Python3) / pybind11 otherwise resolve the box's system python (3.12)
+        # off PATH and emit a cpython-312 ext that pip (running 3.14) can't use.
+        # Putting the bundled interpreter FIRST on PATH makes CMake find 3.14 and
+        # build a cpython-${PYVER} ext (the -D hints alone aren't honored). No-op
+        # when a wheel is used (e.g. stable cp313).
+        export PATH="$VLLM_ROOT/bin:$PATH"
+        export CMAKE_ARGS="${CMAKE_ARGS:-} -DPython3_EXECUTABLE=$VLLM_ROOT/bin/python3 -DPython_EXECUTABLE=$VLLM_ROOT/bin/python3"
+
+        # vLLM's dependency graph trips pip's resolvelib resolver into a
+        # RecursionError (a cycle in its closure), on BOTH channels. No pip flag
+        # controls the recursion depth, so run pip via its entrypoint under a
+        # raised limit; combined with --use-deprecated=legacy-resolver below this
+        # is what lets the install complete. (pip pinned to 24.3.1 in Prepare.)
+        pip_deep() {
+          "$VLLM_ROOT/bin/python3" -c 'import sys; sys.setrecursionlimit(20000); from pip._internal.cli.main import main; sys.exit(main(sys.argv[1:]))' "$@"
+        }
+
+        if [ "$CHANNEL" = "stable" ]; then
+          # STABLE: AMD's per-card matched set — the OLDER one-build-per-gfx
+          # pattern (vLLM at rocm.frameworks.amd.com/whl/<gfx>/, torch at
+          # repo.amd.com/rocm/whl/<gfx>/), NOT the nightly single-RDNA build.
+          # ROCm 7.13 / torch 2.9.1 — a different code-object generation than the
+          # 7.14 nightly, which is the point of this validation run. Same robust
+          # install technique as nightly (legacy resolver + matched-torchvision
+          # repair), pointed at the stable sources.
+          # Pin the cp313 stable vLLM version (don't curl-discover): rocm.
+          # frameworks.amd.com WAF-403s a raw directory-listing GET from the
+          # runner's IP, but pip's PEP503 index access through --extra-index-url
+          # works. Bump this when AMD publishes a newer stable cp313 wheel at
+          # rocm.frameworks.amd.com/whl/gfx1151/vllm/ .
+          VLLM_VER="${{ github.event.inputs.stable_vllm_ver || '0.19.1.dev3+rocm7.13.0.g72ed2b398.d20260513' }}"
+          echo "stable: vLLM==$VLLM_VER"
+          # 1. Matched torch from the stable ROCm index (pulls rocm-sdk-* + triton
+          #    at the rocm7.13.0 ABI). The index carries torch 2.9.1 / 2.10.0 /
+          #    2.11.0 all at +rocm7.13.0; vLLM 0.19.1's own code guards pin it to
+          #    torch 2.9.x (>=2.9.0,<2.10.0), so use 2.9.1. NOTE: even this
+          #    code-correct version currently leaves unresolved c10::*[abi:cxx11]
+          #    symbols (tier0 T0.2) — AMD's stable vLLM wheel was built with a
+          #    different _GLIBCXX_USE_CXX11_ABI than its stable torch. That's an
+          #    upstream ABI skew the gate reports; we do not pin around it.
+          $VLLM_ROOT/bin/pip install --index-url "$TORCH_INDEX" \
+            --extra-index-url https://pypi.org/simple/ \
+            "torch==2.9.1+rocm7.13.0"
+          # 2. vLLM by version from the gfx index + PyPI for the ~70 normal deps.
+          #    Same legacy resolver as nightly (the recursion cycle is in vLLM's
+          #    graph regardless of channel); --ignore-requires-python guards any
+          #    amd-quark cp<3.13 cap.
+          ok=0
+          for attempt in 1 2 3; do
+            if pip_deep install --use-deprecated=legacy-resolver --ignore-requires-python \
+                 --extra-index-url "$VLLM_INDEX" \
+                 --extra-index-url "$TORCH_INDEX" \
+                 --extra-index-url https://pypi.org/simple/ \
+                 "vllm==$VLLM_VER"; then ok=1; break; fi
+            echo "::warning::stable vLLM install attempt $attempt failed; retry in $((attempt*10))s"
+            sleep $((attempt * 10))
+          done
+          [ "$ok" = 1 ] || { echo "::error::stable vLLM install failed after 3 attempts"; exit 1; }
+          # 3. Repair: the legacy resolver may have pulled a PyPI torchvision with
+          #    the wrong torch ABI (torchvision::nms unregistered -> import dies).
+          #    Force the matched ROCm build AFTER vLLM. pycountry is an undeclared
+          #    optional transitive (mistral_common). pip check surfaces the rest.
+          $VLLM_ROOT/bin/pip install --index-url "$TORCH_INDEX" \
+            --extra-index-url https://pypi.org/simple/ \
+            "torchvision==0.24.0+rocm7.13.0"
+          $VLLM_ROOT/bin/pip install pycountry
+          $VLLM_ROOT/bin/pip check || echo "::warning::pip check reported conflicts (see above); qualify will gate"
+        else
+          # NIGHTLY: repackage AMD's OFFICIAL nightly. AMD publishes a single
+          # universal RDNA vLLM wheel plus a date-stamped matched torch; we pair
+          # them by the shared ROCm build stamp (rocm7.14.0a<DATE>), so the set
+          # is ABI-consistent by construction — no pinning around mismatches.
+          # AMD publishes the nightly vLLM as TWO separate per-family lines,
+          # device-all-rdna and device-all-cdna, at independent versions. The
+          # line must therefore follow the matrix target, not be hardcoded.
+          # (torch does NOT: whl-multi-arch carries every arch, including
+          # rocm-sdk-device-gfx942/-gfx950, so the torch half is family-agnostic.)
+          case "${{ matrix.gfx_target }}" in
+            gfx942|gfx950) NIGHTLY_SET=device-all-cdna ;;
+            *)             NIGHTLY_SET=device-all-rdna ;;
+          esac
+          NIGHTLY_VLLM=https://rocm.frameworks-nightlies.amd.com/whl/$NIGHTLY_SET
+          NIGHTLY_TORCH=https://rocm.nightlies.amd.com/whl-multi-arch
+          echo "nightly vLLM line: $NIGHTLY_SET"
+          # torch's per-gfx kernels are an extra; map the matrix target to it.
+          case "${{ matrix.gfx_target }}" in
+            gfx1151) DEV=gfx1151 ;;
+            gfx1150) DEV=gfx1150 ;;
+            gfx110X) DEV=gfx1100 ;;
+            gfx120X) DEV=gfx1200 ;;
+            *) DEV="${{ matrix.gfx_target }}" ;;
+          esac
+          # 1. Use the version detect-nightly already resolved (so detect and
+          #    build agree even if AMD publishes a newer one mid-run); else
+          #    discover the newest cp314 wheel from the index.
+          # detect-nightly probes the RDNA line only (it gates the daily cron),
+          # so its version is valid for RDNA targets ONLY. Reusing it for a CDNA
+          # build would pin a version that does not exist on the CDNA line; leave
+          # it empty so the self-discovery below resolves from $NIGHTLY_VLLM.
+          if [ "$NIGHTLY_SET" = "device-all-rdna" ]; then
+            VLLM_VER="${{ needs.detect-nightly.outputs.vllm_ver }}"
+            ROCM_STAMP="${{ needs.detect-nightly.outputs.rocm_stamp }}"
+          else
+            VLLM_VER=""
+            ROCM_STAMP=""
+          fi
+          if [ -z "$VLLM_VER" ]; then
+            WHL=$(curl -fsSL "$NIGHTLY_VLLM/vllm/" \
+              | grep -oE 'vllm-[0-9][^"]*-cp314-cp314-linux_x86_64\.whl' \
+              | sort | tail -1)
+            VLLM_VER=$(echo "$WHL" | sed -E 's/^vllm-(.*)-cp314-cp314-linux_x86_64\.whl$/\1/' | sed 's/%2B/+/g')
+            ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
+          fi
+          [ -n "$VLLM_VER" ] || { echo "::error::no cp314 nightly vLLM version found"; exit 1; }
+          # Omni builds pin the qualified base (vLLM-Omni 0.23.0rc1 can't ride
+          # the latest nightly — see OMNI_BASE_VLLM_VER). Override the detected
+          # version so build/qualify/release all use the validated base.
+          if [ "$OMNI" = "true" ]; then
+            VLLM_VER="$OMNI_BASE_VLLM_VER"
+            ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
+            echo "omni: pinning base to $VLLM_VER (stamp $ROCM_STAMP)"
+          fi
+          # upstream vLLM 0.21.x pins torch 2.11.0 (the wheel itself strips it);
+          # bump TORCH_VER here when vLLM bumps its torch requirement.
+          TORCH_VER=2.11.0
+          echo "nightly: vLLM==$VLLM_VER"
+          echo "nightly: torch=${TORCH_VER}+${ROCM_STAMP}[device-${DEV}]"
+          # 2. Matched torch + ROCm runtime libs + Triton + per-gfx kernels,
+          #    all resolved at the same ROCm stamp from one index.
+          $VLLM_ROOT/bin/pip install --index-url "$NIGHTLY_TORCH" \
+            --extra-index-url https://pypi.org/simple/ \
+            "torch[device-${DEV}]==${TORCH_VER}+${ROCM_STAMP}"
+          # 3a. Pre-install amd-quark. vLLM pins amd-quark>=0.8.99, but every
+          #    amd-quark >=0.7 on PyPI caps Requires-Python at <3.13 while our
+          #    nightly bundle is cp314. amd-quark is a pure-Python (py3-none-any) wheel —
+          #    the cap is a conservative untested-version guard, not a real ABI
+          #    limit — so install it ALONE with --ignore-requires-python (a tiny
+          #    candidate space). Scoping the flag here, not on the vLLM resolve,
+          #    is deliberate: passed globally it strips the Python filter from
+          #    every dep, ballooning pip's backtracking until it RecursionErrors.
+          #    Once installed and satisfying >=0.8.99, vLLM's resolve accepts it.
+          pip_deep install --ignore-requires-python "amd-quark>=0.8.99"
+          # 3b. The universal vLLM wheel + flash-attn (AMD index) + the rest from
+          #    PyPI. Install BY VERSION through the index (not a hand-built wheel
+          #    URL): the host serves the wheel only at its %2B-encoded path, so a
+          #    direct URL with a literal '+' gets WAF-403'd. Letting pip resolve
+          #    the index href fetches the correctly-encoded URL. vLLM declares no
+          #    torch dep, so the matched torch above is untouched.
+          #    Two flags, both required and complementary:
+          #    --use-deprecated=legacy-resolver: the new resolvelib resolver
+          #    RecursionErrors building its result graph on a cycle in vLLM's
+          #    dependency closure (resolution.py:_has_route_to_root recurses
+          #    without end). The legacy resolver doesn't walk that graph. (pip is
+          #    pinned to 24.3.1 above so this flag still exists.)
+          #    --ignore-requires-python: the legacy resolver re-checks
+          #    requires-python on the already-installed amd-quark (capped <3.13)
+          #    and hard-errors on cp314; the flag makes it accept it. On
+          #    the legacy (first-found, no-backtrack) resolver this can't balloon
+          #    the candidate search the way it would on the new resolver.
+          ok=0
+          for attempt in 1 2 3; do
+            if pip_deep install --use-deprecated=legacy-resolver --ignore-requires-python \
+                 --extra-index-url "$NIGHTLY_VLLM" \
+                 --extra-index-url https://pypi.org/simple/ \
+                 "vllm==$VLLM_VER"; then ok=1; break; fi
+            echo "::warning::vLLM install attempt $attempt failed; retry in $((attempt*10))s"
+            sleep $((attempt * 10))
+          done
+          [ "$ok" = 1 ] || { echo "::error::vLLM install failed after 3 attempts"; exit 1; }
+          # 3c. Repair legacy-resolver over-picks. The legacy resolver takes the
+          #    first-found version and ignores transitive UPPER bounds / ABI, so
+          #    it leaves deps that break vLLM at import (each caught by qualify
+          #    T1.5). Re-assert the correct ones here (small single-package
+          #    resolves — no cycle), then `pip check` surfaces any remaining
+          #    mis-pick in the build log without failing the build (qualify gates).
+          #
+          #    torchvision must match the ROCm torch ABI or its C++ ops
+          #    (torchvision::nms) fail to register and `import vllm` dies. Legacy
+          #    pulled a PyPI torchvision built against a different torch; force the
+          #    matched ROCm build from the nightly index, same rocm stamp. torch
+          #    2.11 pairs with torchvision 0.26 — bump TV_VER with TORCH_VER.
+          TV_VER=0.26.0
+          $VLLM_ROOT/bin/pip install --index-url "$NIGHTLY_TORCH" \
+            --extra-index-url https://pypi.org/simple/ \
+            "torchvision==${TV_VER}+${ROCM_STAMP}"
+          #    transformers needs tokenizers>=0.22.0,<=0.23.0 but legacy pulled
+          #    0.23.1, raising ImportError at import; pin it back into range.
+          $VLLM_ROOT/bin/pip install "tokenizers>=0.22.0,<=0.23.0"
+          #    pycountry: an OPTIONAL transitive nothing declares as a hard dep
+          #    (vLLM -> mistral_common -> pydantic_extra_types.language_code ->
+          #    pycountry), so no resolver installs it, yet mistral_common imports
+          #    it at module load and vllm-server dies without it. Add explicitly.
+          $VLLM_ROOT/bin/pip install pycountry
+          $VLLM_ROOT/bin/pip check || echo "::warning::pip check reported dependency conflicts (see above); qualify will gate"
+        fi
+
+        # Use the AMD pip ROCm SDK amdsmi (_rocm_sdk_core/share/amd_smi) rather
+        # than any amdsmi the wheels bundled.
+        rm -rf $SP/amdsmi $SP/amdsmi-*.dist-info
+
+        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
+          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        export LD_LIBRARY_PATH
+        # Report versions but DO NOT fail the build on a bad combination — a
+        # broken bundle must still be packaged so the qualification gate can
+        # detect and REPORT it. Fixing upstream is never our job.
+        $VLLM_ROOT/bin/python3 -c "
+        import torch; print(f'PyTorch {torch.__version__}')
+        import vllm; print(f'vLLM {vllm.__version__}')
+        " || echo "WARNING: import check failed — qualification will report this"
+
+    - name: Pre-compile Triton HIP utilities (eliminates gcc dependency)
+      run: |
+        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
+        TRITON_AMD="$SP/triton/backends/amd"
+        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
+          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        export LD_LIBRARY_PATH
+
+        # Create unversioned symlinks for ROCm libs (pip installs only have versioned .so.N)
+        ROCM_LIB="$SP/_rocm_sdk_core/lib"
+        for lib in "$ROCM_LIB"/*.so.*; do
+          name=$(basename "$lib")
+          link="$ROCM_LIB/${name%%.*}.so"
+          [ ! -e "$link" ] && ln -sf "$name" "$link"
+        done
+        ls -la "$ROCM_LIB/libamdhip64.so" || echo "WARNING: symlink not created"
+
+        # Compile the hip_utils C module with gcc directly and save into the package.
+        # We can't use Triton's compile_module_from_src because it also tries to
+        # dlopen the HIP library, which doesn't work on headless CI.
+        TRITON_AMD="$SP/triton/backends/amd"
+        PYTHON_INC="$VLLM_ROOT/include/python${PYVER}"
+
+        # Generate the C source with the HIP library path baked in
+        $VLLM_ROOT/bin/python3 -c "
+        from pathlib import Path
+        import os
+        dirname = '$TRITON_AMD'
+        src = Path(os.path.join(dirname, 'driver.c')).read_text()
+        # Bake in the relative path that will resolve at runtime via LD_LIBRARY_PATH
+        src = src.replace('/*py_libhip_search_path*/', 'libamdhip64.so', 1)
+        Path('/tmp/hip_utils.c').write_text(src)
+        print('Generated /tmp/hip_utils.c')
+        "
+
+        # Compile with gcc
+        gcc /tmp/hip_utils.c -O3 -shared -fPIC -Wno-psabi \
+          -o "$TRITON_AMD/hip_utils_prebuilt.so" \
+          -I"$TRITON_AMD/include" \
+          -I"$PYTHON_INC"
+        echo "Pre-compiled: $TRITON_AMD/hip_utils_prebuilt.so ($(stat -c%s "$TRITON_AMD/hip_utils_prebuilt.so") bytes)"
+
+        # Patch Triton to load the pre-built .so instead of JIT-compiling
+        DRIVER_PY="$TRITON_AMD/driver.py"
+        sed -i 's|mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|_pso = os.path.join(dirname, "hip_utils_prebuilt.so")\n        if os.path.exists(_pso):\n            import importlib.util as _ilu\n            _sp = _ilu.spec_from_file_location("hip_utils", _pso)\n            mod = _ilu.module_from_spec(_sp)\n            _sp.loader.exec_module(mod)\n        else:\n            mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|' "$DRIVER_PY"
+        $VLLM_ROOT/bin/python3 -c "import ast; ast.parse(open('$DRIVER_PY').read()); print('Patched driver.py — syntax OK')"
+
+    - name: Create launcher script
+      run: |
+        cat > $VLLM_ROOT/bin/vllm-server << 'LAUNCHER_EOF'
+        #!/bin/bash
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        VENV_DIR="$(dirname "$SCRIPT_DIR")"
+        # Glob the bundled python3.* dir so the launcher is Python-version-agnostic
+        # (the bundle is cp313 or cp314 depending on channel).
+        SP="$(echo "$VENV_DIR"/lib/python3.*/site-packages)"
+        # Add all bundled ROCm library paths
+        for libdir in "$SP"/_rocm_sdk_*/lib "$SP"/torch/lib; do
+        [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        # Also add LLVM lib for the bundled clang
+        LD_LIBRARY_PATH="$SP/_rocm_sdk_core/lib/llvm/lib:${LD_LIBRARY_PATH}"
+        export LD_LIBRARY_PATH
+        export PYTHONPATH="$SP/_rocm_sdk_core/share/amd_smi:${PYTHONPATH:-}"
+        export FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
+        # Use bundled clang for Triton JIT (no system gcc needed)
+        CLANG="$SP/_rocm_sdk_core/lib/llvm/bin/clang"
+        [ -f "$CLANG" ] && chmod +x "$CLANG" "$CLANG"-* 2>/dev/null
+        export CC="$CLANG"
+        exec "$SCRIPT_DIR/python3" -m vllm.entrypoints.openai.api_server "$@"
+        LAUNCHER_EOF
+
+        # Remove YAML indentation from heredoc
+        sed -i 's/^        //' $VLLM_ROOT/bin/vllm-server
+        chmod +x $VLLM_ROOT/bin/vllm-server
+        echo "Launcher script:"
+        cat $VLLM_ROOT/bin/vllm-server
+
+    - name: Strip unnecessary files to reduce size
+      run: |
+        cd $VLLM_ROOT
+        echo "=== Size before cleanup ==="
+        du -sh .
+
+        SP="lib/python${PYVER}/site-packages"
+
+        # Remove pip/wheel (keep setuptools — torch.utils.cpp_extension needs it)
+        rm -rf $SP/pip* $SP/wheel* 2>/dev/null || true
+
+        # Remove __pycache__ and .pyc
+        find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+        find . -name "*.pyc" -delete 2>/dev/null || true
+
+        # Remove test/benchmark dirs (but NOT torch.testing — it's imported at runtime)
+        rm -rf $SP/torch/test $SP/torch/benchmarks 2>/dev/null || true
+
+        # Remove packages not needed for inference serving (~500MB)
+        rm -rf $SP/pyarrow* $SP/opencv* $SP/cv2* 2>/dev/null || true
+        rm -rf $SP/onnx* $SP/pandas* $SP/plotly* 2>/dev/null || true
+        rm -rf $SP/datasets* $SP/evaluate* $SP/peft* $SP/timm* 2>/dev/null || true
+        rm -rf $SP/boto3* $SP/botocore* $SP/s3transfer* 2>/dev/null || true
+        rm -rf $SP/azure* $SP/google_cloud* $SP/google_auth* $SP/msal* 2>/dev/null || true
+        rm -rf $SP/tensorizer* $SP/runai* 2>/dev/null || true
+        rm -rf $SP/aiter_meta* 2>/dev/null || true
+
+        # Trim LLVM toolchain: keep only clang + its libs (~350MB saved)
+        LLVM="$SP/_rocm_sdk_core/lib/llvm"
+        # Keep the clang driver and its versioned binary (clang-NN). The LLVM
+        # major tracks the ROCm release (clang-22 on 7.13, clang-23 on 7.14);
+        # hardcoding clang-22 would delete the real compiler on newer ROCm and
+        # break Triton's runtime JIT. Match clang-* so it survives any version.
+        find "$LLVM/bin" -type f ! -name "clang" ! -name "clang-*" -delete 2>/dev/null || true
+        find "$LLVM/bin" -type l ! -name "clang" -delete 2>/dev/null || true
+        # Keep only libs that clang needs (libclang-cpp, libLLVM, rocm_sysdeps)
+        find "$LLVM/lib" -name "*.so*" \
+          ! -name "libclang-cpp*" \
+          ! -name "libLLVM*" \
+          -delete 2>/dev/null || true
+        rm -rf "$LLVM/lib/clang/"*/include/cuda_wrappers 2>/dev/null || true
+
+        # Trim ROCm SDK bin/ (Python wrapper scripts, not needed)
+        rm -rf "$SP/_rocm_sdk_core/bin" 2>/dev/null || true
+
+        # Remove Python stdlib we don't need
+        rm -rf lib/python${PYVER}/test lib/python${PYVER}/tkinter lib/python${PYVER}/idlelib 2>/dev/null || true
+        rm -rf lib/python${PYVER}/turtledemo lib/python${PYVER}/ensurepip 2>/dev/null || true
+        # Keep include/ — Triton JIT needs Python.h headers
+
+        # Ensure bundled clang is executable (permissions lost during tar)
+        chmod +x "$LLVM/bin/clang"* 2>/dev/null || true
+
+        # NOTE: Do NOT strip .so files — AMD ROCm wheels use special ELF
+        # alignment that strip corrupts, and numpy/scipy also break.
+
+        echo "=== Size after cleanup ==="
+        du -sh .
+        echo ""
+        echo "Top consumers:"
+        du -sh $SP/torch/ $SP/vllm/ $SP/_rocm_sdk_core/ $SP/aiter/ $SP/triton/ 2>/dev/null || true
+
+    - name: Layer vLLM-Omni onto the bundle (omni builds only)
+      # MUST run AFTER the Strip step: Strip deletes opencv/onnx/peft/timm (and
+      # pip) — exactly the deps the omni layer reinstalls. build_omni_layer.sh
+      # re-bootstraps pip and pulls vllm-omni + its runtime/multimodal deps + an
+      # ABI-matched torchaudio. torchaudio must come from the SAME ROCm index as
+      # the bundled torch: per-gfx stable index on the stable channel, AMD's
+      # multi-arch nightly index on nightly.
+      if: ${{ env.OMNI == 'true' }}
+      env:
+        TORCH_INDEX: ${{ env.CHANNEL == 'stable' && steps.wheel-urls.outputs.torch_index || 'https://rocm.nightlies.amd.com/whl-multi-arch' }}
+      run: |
+        bash scripts/build_omni_layer.sh
+
+    - name: Verify bundled environment works
+      run: |
+        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
+        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
+          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        export LD_LIBRARY_PATH
+
+        $VLLM_ROOT/bin/python3 -c "import vllm; print(f'vLLM {vllm.__version__} OK')"
+        $VLLM_ROOT/bin/python3 -c "import torch; print(f'PyTorch {torch.__version__} OK')"
+        $VLLM_ROOT/bin/python3 -c "
+        # Verify native extensions exist (they load only with GPU present)
+        import os, pathlib
+        sp = pathlib.Path('$SP/vllm')
+        for ext in ['_C.abi3.so', '_rocm_C.abi3.so']:
+            p = sp / ext
+            assert p.exists(), f'Missing {ext}'
+            print(f'{ext}: {p.stat().st_size // 1048576} MB')
+        print('Native extensions verified')
+        "
+        bash -n $VLLM_ROOT/bin/vllm-server
+        echo "All sanity checks passed"
+
+    - name: Report final size
+      run: |
+        echo "=== Final artifact ==="
+        du -sh $VLLM_ROOT/
+        echo ""
+        du -sh $VLLM_ROOT/*/ 2>/dev/null
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ephemeral-vllm-ubuntu-rocm-${{ matrix.gfx_target }}-x64
+        path: ${{ env.VLLM_ROOT }}/
+        # CRITICAL: the AMD ROCm wheels ship the per-gfx GPU code objects in
+        # HIDDEN dot-dirs (torch/.kpack/torch_gfx1151.kpack,
+        # _rocm_sdk_libraries/.kpack/{blas,fft,rand,rccl}_lib_gfx1151.kpack,
+        # .devel_links/). Since v4, upload-artifact EXCLUDES hidden files by
+        # default — dropping these silently produces a bundle that loads and
+        # enumerates the GPU but dies on the first kernel launch with
+        # hipErrorInvalidImage. include-hidden-files keeps them. Do not remove.
+        include-hidden-files: true
+        retention-days: 7
+        compression-level: 6
+
+    - name: Set job outputs
+      id: set-outputs
+      run: |
+        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
+        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
+          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
+        done
+        export LD_LIBRARY_PATH
+
+        vllm_ver=$($VLLM_ROOT/bin/python3 -c "import vllm; print(vllm.__version__)")
+        torch_ver=$($VLLM_ROOT/bin/python3 -c "import torch; print(torch.__version__)")
+        echo "vllm_version=$vllm_ver" >> $GITHUB_OUTPUT
+        echo "torch_version=$torch_ver" >> $GITHUB_OUTPUT
+        # Empty on non-omni builds. Read from dist-info (no heavy import) so the
+        # create-release tag can distinguish vllm-omni* artifacts.
+        omni_ver=$(ls -d "$SP"/vllm_omni-*.dist-info 2>/dev/null | head -1 \
+          | sed -E 's#.*/vllm_omni-(.*)\.dist-info#\1#')
+        echo "omni_version=$omni_ver" >> $GITHUB_OUTPUT
+
+    - name: Clean up
+      if: always()
+      run: |
+        # No sudo — it's under the runner's temp dir. Free the box for the next run.
+        rm -rf "$RUNNER_TEMP/vllm-build" || true
+
+
+  qualify-ephemeral:
+    needs: build-ubuntu-ephemeral
+    runs-on: [self-hosted, Linux, strix-halo, ephemeral]
+    continue-on-error: true
+    env:
+      GFX: gfx1151
+    # Matches build-ubuntu-ephemeral rather than the release path's gate.
+    # The persistent qualify additionally requires create_release or omni on
+    # a dispatch; that guards a release, and this job cannot make one.
+    if: github.event_name != 'pull_request'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Download gfx1151 artifact
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        WORK="${{ runner.temp }}/vllm-qual"
+        DEST="$WORK/vllm"
+        ZIP="$WORK/artifact.zip"
+        mkdir -p "$DEST"
+        echo "=== Disk before download ==="; df -h "$WORK" || true
+
+        # The build artifact is ~3.3 GB (extracts to ~11 GB). actions/download-artifact@v4
+        # is unreliable for artifacts this size on self-hosted runners, so pull the
+        # artifact zip directly with curl (streams to disk, resumable) and unzip it.
+        # Resolve the artifact id via the REST API with curl + python3 — the box
+        # does not have the gh CLI installed.
+        ART_ID=$(curl -fsSL \
+                   -H "Authorization: Bearer $GH_TOKEN" \
+                   -H "Accept: application/vnd.github+json" \
+                   "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+                 | python3 -c "import sys,json; print(next((a['id'] for a in json.load(sys.stdin)['artifacts'] if a['name']=='ephemeral-vllm-ubuntu-rocm-gfx1151-x64'), ''))")
+        [ -n "$ART_ID" ] || { echo "::error::gfx1151 artifact not found for this run"; exit 1; }
+        echo "Artifact id: $ART_ID"
+
+        avail_gb=$(df -BG --output=avail "$WORK" | tail -1 | tr -dc '0-9')
+        echo "Available space: ${avail_gb} GB"
+        if [ "${avail_gb:-0}" -lt 15 ]; then
+          echo "::error::Only ${avail_gb} GB free on the runner; need ~15 GB for the 11 GB build."
+          exit 1
+        fi
+
+        ok=0
+        for attempt in 1 2 3; do
+          echo "=== curl attempt $attempt ==="
+          if curl -fL --retry 5 --retry-delay 10 --retry-all-errors -C - \
+                  -H "Authorization: Bearer $GH_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  -o "$ZIP" \
+                  "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${ART_ID}/zip"; then
+            ok=1; break
+          fi
+          echo "attempt $attempt failed; retrying in 15s"; sleep 15
+        done
+        [ "$ok" = "1" ] || { echo "::error::artifact zip download failed after 3 attempts"; df -h "$WORK" || true; exit 1; }
+        echo "Downloaded zip: $(du -h "$ZIP" | cut -f1)"
+
+        echo "=== Extracting ==="
+        if command -v unzip >/dev/null 2>&1; then
+          unzip -q -o "$ZIP" -d "$DEST"
+        else
+          python3 -m zipfile -e "$ZIP" "$DEST"
+        fi
+        rm -f "$ZIP"   # reclaim space immediately
+        echo "Extracted $(du -sh "$DEST" | cut -f1) to $DEST"
+        echo "=== Disk after extract ==="; df -h "$WORK" || true
+
+    - name: Restore permissions and ROCm symlinks
+      run: |
+        # upload-artifact drops the +x bit and the unversioned .so symlinks the
+        # build created, so rebuild both before running the harness.
+        ROOT="${{ runner.temp }}/vllm-qual/vllm"
+        # The bundle's Python version is channel-dependent (cp313 stable / cp314
+        # nightly); glob it rather than hardcode.
+        SP="$(echo "$ROOT"/lib/python3.*/site-packages)"
+        chmod +x "$ROOT/bin/"* 2>/dev/null || true
+        chmod +x "$SP/_rocm_sdk_core/lib/llvm/bin/"clang* 2>/dev/null || true
+        ROCM_LIB="$SP/_rocm_sdk_core/lib"
+        for lib in "$ROCM_LIB"/*.so.*; do
+          [ -e "$lib" ] || continue
+          name=$(basename "$lib"); link="$ROCM_LIB/${name%%.*}.so"
+          # Use `if` (not `&&`) so a pre-existing symlink doesn't leave the loop
+          # with exit 1 and trip `set -e`. The artifact preserves these symlinks,
+          # so this is now mostly a defensive no-op.
+          if [ ! -e "$link" ]; then ln -sf "$name" "$link"; fi
+        done
+
+    - name: Run 16-test qualification (tier0 + tier1 + tier2)
+      id: qual
+      run: |
+        WORK="${{ runner.temp }}/vllm-qual"
+        ROOT="$WORK/vllm"
+        PY="$ROOT/bin/python3"
+        FRAG="$WORK/fragments"; mkdir -p "$FRAG"
+        Q="$GITHUB_WORKSPACE/scripts/qualify"
+        TAG="vllm${{ needs.build-ubuntu-ephemeral.outputs.vllm_version }}-${GFX}"
+        # Omni builds qualify the omni serving path and record an omni candidate tag.
+        if [ "$OMNI" = "true" ]; then
+          TAG="vllm-omni${{ needs.build-ubuntu-ephemeral.outputs.omni_version }}-${GFX}"
+        fi
+
+        # The tiers are run WITHOUT --fail-on-error so all 16 tests execute and
+        # emit a JSON fragment even when one fails; `aggregate --fail-on-no-promote`
+        # is the single gate that decides pass/fail for the whole job.
+        echo "::group::Tier 0 — static bundle verification (T0.1–T0.6)"
+        "$PY" "$Q/tier0_static.py"   --bundle-root "$ROOT" --gfx-target "$GFX" \
+            --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier0-report.json" || true
+        echo "::endgroup::"
+
+        echo "::group::Tier 1 — hardware smoke (T1.1–T1.5)"
+        "$PY" "$Q/tier1_smoke.py"    --bundle-root "$ROOT" --gfx-target "$GFX" \
+            --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier1-report.json" || true
+        echo "::endgroup::"
+
+        # Tier 2 functional inference. Omni bundles run the omni serving path
+        # (vllm-omni-server + single-GPU deploy config) instead of plain vLLM;
+        # both emit a `tier2` fragment so the aggregate require-tiers rule is
+        # identical. The two are mutually exclusive per run.
+        if [ "$OMNI" = "true" ]; then
+          echo "::group::Tier 2 (omni) — functional inference via vllm-omni-server"
+          "$PY" "$Q/tier2_omni.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
+              --channel "$CHANNEL" --candidate-tag "$TAG" --logs-dir "$FRAG" \
+              --output "$FRAG/tier2-report.json" || true
+          echo "::endgroup::"
+        else
+          echo "::group::Tier 2 — functional inference (T2.1–T2.5)"
+          "$PY" "$Q/tier2_inference.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
+              --channel "$CHANNEL" --candidate-tag "$TAG" \
+              --model Qwen/Qwen2.5-0.5B-Instruct --logs-dir "$FRAG" \
+              --output "$FRAG/tier2-report.json" || true
+          echo "::endgroup::"
+        fi
+
+        echo "=== Aggregate fragments → qualification report (gates the job) ==="
+        "$PY" "$Q/aggregate.py" --fragments-dir "$FRAG" --gfx-target "$GFX" \
+            --channel "$CHANNEL" --candidate-tag "$TAG" \
+            --require-tiers tier0,tier1,tier2 --hardware-validated \
+            --output "$FRAG/qualification-report.json" \
+            --fail-on-no-promote
+
+    - name: Upload qualification report and fragments
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ephemeral-qualification-gfx1151
+        path: |
+          ${{ runner.temp }}/vllm-qual/fragments/*.json
+          ${{ runner.temp }}/vllm-qual/fragments/*.log
+        if-no-files-found: warn
+
+    - name: Tear down and clean up
+      if: always()
+      run: |
+        # Redundant on an ephemeral runner -- the VM is destroyed after the
+        # job -- but kept so the two job bodies stay comparable.
+        WORK="${{ runner.temp }}/vllm-qual"
+        pkill -9 -f "vllm.entrypoints.openai.api_server" 2>/dev/null || true
+        rm -rf "$WORK" || true
+
+
   # Publish the qualification result (pass OR fail) to the qualification-data
   # branch so the external dashboard can poll it. Runs on a hosted runner (the
   # GPU box has no gh/git tooling). Contract: docs/qualification-feed.md.

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -178,6 +178,8 @@ jobs:
       qualify_matrix: ${{ steps.set-matrix.outputs.qualify_matrix }}
       qualify_targets: ${{ steps.set-matrix.outputs.qualify_targets }}
       qualify_count: ${{ steps.set-matrix.outputs.qualify_count }}
+      ephemeral_matrix: ${{ steps.set-matrix.outputs.ephemeral_matrix }}
+      ephemeral_count: ${{ steps.set-matrix.outputs.ephemeral_count }}
     steps:
     - name: Set matrix
       id: set-matrix
@@ -192,28 +194,58 @@ jobs:
         echo "ubuntu_matrix=$matrix_targets" >> $GITHUB_OUTPUT
         echo "Generated matrix: $matrix_targets"
 
-        # Targets with qualification hardware, mapped to the self-hosted runner
-        # group that owns each. The qualify job runs one leg per selected target
-        # that appears here; targets absent from this registry build and release
-        # exactly as before (qualify skips them -> release ungated, unchanged).
-        # Adding a runner for a new target (e.g. a CDNA box for gfx942) is a
-        # one-line addition to this map.
-        QUALIFIED_RUNNERS='{"gfx1151":"dev_lab"}'
-        qualify_matrix=$(echo "$targets" \
+        # Targets with qualification hardware, mapped to every pool that owns
+        # some. The qualify jobs run one leg per selected target that appears
+        # here; targets absent from this registry build and release exactly as
+        # before (qualify skips them -> release ungated, unchanged). Adding
+        # hardware for a new target (e.g. a CDNA box for gfx942) is a one-line
+        # addition to this map.
+        #
+        # A pool is addressed one of two ways, and the difference is not
+        # cosmetic:
+        #   dev_lab    a runner GROUP -- a shared, persistent box, selected
+        #              with `group:` so a leg cannot land on a Linux box in
+        #              another group the repo can also see (Default is
+        #              visibility:all).
+        #   ephemeral  a LABEL pool -- per-job VMs from an orchestrator, which
+        #              registers its runners to the REPO. A repo-registered
+        #              runner is always in the repo's Default group, so
+        #              `group:` can never select it; it is reached by its
+        #              specific labels instead.
+        # 'ephemeral' is the one pool name that means labels rather than a
+        # group, which is why it is split out below.
+        QUALIFICATION_POOLS='{"gfx1151":["dev_lab","ephemeral"]}'
+        selected=$(echo "$targets" \
           | tr ',' '\n' \
           | sed 's/^ *//;s/ *$//' \
           | jq -R . \
-          | jq -s --argjson q "$QUALIFIED_RUNNERS" \
-              'unique | {include: [.[] | select($q[.] != null) | {gfx: ., runner_group: $q[.]}]}' \
-          | jq -c)
+          | jq -sc 'unique')
+
+        # One leg per (target, runner group) -- the release path.
+        qualify_matrix=$(echo "$selected" \
+          | jq -c --argjson q "$QUALIFICATION_POOLS" \
+              '{include: [.[] | . as $t | ($q[$t] // [])[]
+                          | select(. != "ephemeral")
+                          | {gfx: $t, runner_group: .}]}')
+        # One leg per target the ephemeral pool can serve. Same registry, so a
+        # target can never be soaked on hardware it is not qualified on.
+        ephemeral_matrix=$(echo "$selected" \
+          | jq -c --argjson q "$QUALIFICATION_POOLS" \
+              '{include: [.[] | . as $t | ($q[$t] // [])[]
+                          | select(. == "ephemeral")
+                          | {gfx_target: $t}]}')
         # JSON array (not a comma list): consumers use fromJson() set membership,
         # so no target string can substring-match another.
         qualify_targets=$(echo "$qualify_matrix" | jq -c '[.include[].gfx]')
         qualify_count=$(echo "$qualify_matrix" | jq -r '.include | length')
+        ephemeral_count=$(echo "$ephemeral_matrix" | jq -r '.include | length')
         echo "qualify_matrix=$qualify_matrix" >> $GITHUB_OUTPUT
         echo "qualify_targets=$qualify_targets" >> $GITHUB_OUTPUT
         echo "qualify_count=$qualify_count" >> $GITHUB_OUTPUT
+        echo "ephemeral_matrix=$ephemeral_matrix" >> $GITHUB_OUTPUT
+        echo "ephemeral_count=$ephemeral_count" >> $GITHUB_OUTPUT
         echo "Qualify matrix: $qualify_matrix"
+        echo "Ephemeral matrix: $ephemeral_matrix"
 
   build-ubuntu:
     # Target the dev_lab runner GROUP explicitly, not just labels. The org's
@@ -255,676 +287,31 @@ jobs:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.ubuntu_matrix)}}
       fail-fast: false
     outputs:
-      vllm_version: ${{ steps.set-outputs.outputs.vllm_version }}
-      torch_version: ${{ steps.set-outputs.outputs.torch_version }}
+      vllm_version: ${{ steps.build.outputs.vllm_version }}
+      torch_version: ${{ steps.build.outputs.torch_version }}
       # Non-empty only on omni builds; create-release uses it to pick the tag.
-      omni_version: ${{ steps.set-outputs.outputs.omni_version }}
+      omni_version: ${{ steps.build.outputs.omni_version }}
 
     steps:
+    # The repo has to be on disk before a local action can be resolved.
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Download portable Python (python-build-standalone)
-      run: |
-        # Relocatable Python from astral-sh/python-build-standalone — no system
-        # Python/ROCm dependency. The Python version is CHANNEL-DRIVEN because the
-        # two channels' vLLM wheels target different CPython ABIs:
-        #   nightly -> cp314 (AMD's device-all-rdna nightly moved to Python 3.14)
-        #   stable  -> cp313 (AMD's per-gfx stable vLLM is still cp313)
-        # PYVER is exported so every later build step uses the right lib/ path,
-        # and qualify re-derives it from the bundle.
-        if [ "$CHANNEL" = "stable" ]; then
-          PYVER=3.13; PBS_TAG=20260602; PBS_PY=3.13.13
-        else
-          PYVER=3.14; PBS_TAG=20260623; PBS_PY=3.14.6
-        fi
-        PBS_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_TAG}/cpython-${PBS_PY}+${PBS_TAG}-x86_64-unknown-linux-gnu-install_only.tar.gz"
-        echo "channel=$CHANNEL -> Python $PBS_PY (cp${PYVER/./})"
-        echo "Downloading portable Python from $PBS_URL"
-        # Build under the runner's temp dir — no sudo, no shared-box pollution,
-        # and isolated per run (the self-hosted boxes are persistent). VLLM_ROOT
-        # is exported so every later step (and the artifact upload) uses it.
-        ROOT="$RUNNER_TEMP/vllm-build/vllm"
-        rm -rf "$RUNNER_TEMP/vllm-build"
-        mkdir -p "$RUNNER_TEMP/vllm-build"
-        # Extracts to python/ — move to vllm/ so it becomes the release root
-        curl -fsSL "$PBS_URL" | tar -xz -C "$RUNNER_TEMP/vllm-build"
-        mv "$RUNNER_TEMP/vllm-build/python" "$ROOT"
-        "$ROOT/bin/python${PYVER}" --version
-        echo "VLLM_ROOT=$ROOT" >> "$GITHUB_ENV"
-        echo "PYVER=$PYVER" >> "$GITHUB_ENV"
-        echo "Portable Python installed at $ROOT"
-
-    - name: Map GPU target to AMD wheel URLs
-      id: wheel-urls
-      run: |
-        target="${{ matrix.gfx_target }}"
-
-        # Map targets to AMD wheel URL suffixes
-        # See: https://rocm.docs.amd.com/en/latest/rocm-for-ai/vllm.html
-        case "$target" in
-          gfx110X) suffix="gfx110X-all" ;;
-          gfx1151) suffix="gfx1151" ;;
-          gfx1150) suffix="gfx1150" ;;
-          gfx120X) suffix="gfx120X-all" ;;
-          # CDNA. These suffixes are the STABLE-channel per-card aisles; the
-          # nightly channel uses AMD's device-all-cdna line instead (resolved in
-          # the install step, which is the only place the channel is known).
-          gfx942) suffix="gfx94X-dcgpu" ;;
-          gfx950) suffix="gfx950-dcgpu" ;;
-          *)
-            echo "ERROR: No AMD pre-built wheels for target: $target"
-            exit 1
-            ;;
-        esac
-
-        echo "torch_index=https://repo.amd.com/rocm/whl/${suffix}/" >> $GITHUB_OUTPUT
-        echo "vllm_index=https://rocm.frameworks.amd.com/whl/${suffix}/" >> $GITHUB_OUTPUT
-        echo "Using PyTorch index: https://repo.amd.com/rocm/whl/${suffix}/"
-        echo "Using vLLM index: https://rocm.frameworks.amd.com/whl/${suffix}/"
-
-    - name: Prepare Python environment
-      run: |
-        # No venv needed — install packages directly into the standalone Python.
-        # Pin pip to 24.3.1: it still ships --use-deprecated=legacy-resolver,
-        # which the vLLM install needs. The current resolvelib resolver
-        # RecursionErrors building its result graph on a dependency cycle in
-        # vLLM's closure (resolution.py:_has_route_to_root recurses infinitely,
-        # so no setrecursionlimit saves it); the legacy resolver avoids that path.
-        $VLLM_ROOT/bin/python3 -m pip install "pip==24.3.1"
-        echo "pip: $($VLLM_ROOT/bin/pip --version)"
-        echo "Python: $($VLLM_ROOT/bin/python3 --version)"
-
-    - name: Install vLLM + PyTorch (channel=${{ env.CHANNEL }})
-      run: |
-        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
-        TORCH_INDEX="${{ steps.wheel-urls.outputs.torch_index }}"
-        VLLM_INDEX="${{ steps.wheel-urls.outputs.vllm_index }}"
-
-        # Steer any CMake-based source build (notably onnx, pulled by amd-quark)
-        # at our bundled Python. On cp314/x86_64 some deps have no wheel yet —
-        # onnx 1.19.0 (amd-quark caps onnx<=1.19.0) only ships a cp314 *aarch64*
-        # wheel, so x86_64 falls back to the sdist. onnx's CMake find_package
-        # (Python3) / pybind11 otherwise resolve the box's system python (3.12)
-        # off PATH and emit a cpython-312 ext that pip (running 3.14) can't use.
-        # Putting the bundled interpreter FIRST on PATH makes CMake find 3.14 and
-        # build a cpython-${PYVER} ext (the -D hints alone aren't honored). No-op
-        # when a wheel is used (e.g. stable cp313).
-        export PATH="$VLLM_ROOT/bin:$PATH"
-        export CMAKE_ARGS="${CMAKE_ARGS:-} -DPython3_EXECUTABLE=$VLLM_ROOT/bin/python3 -DPython_EXECUTABLE=$VLLM_ROOT/bin/python3"
-
-        # vLLM's dependency graph trips pip's resolvelib resolver into a
-        # RecursionError (a cycle in its closure), on BOTH channels. No pip flag
-        # controls the recursion depth, so run pip via its entrypoint under a
-        # raised limit; combined with --use-deprecated=legacy-resolver below this
-        # is what lets the install complete. (pip pinned to 24.3.1 in Prepare.)
-        pip_deep() {
-          "$VLLM_ROOT/bin/python3" -c 'import sys; sys.setrecursionlimit(20000); from pip._internal.cli.main import main; sys.exit(main(sys.argv[1:]))' "$@"
-        }
-
-        if [ "$CHANNEL" = "stable" ]; then
-          # STABLE: AMD's per-card matched set — the OLDER one-build-per-gfx
-          # pattern (vLLM at rocm.frameworks.amd.com/whl/<gfx>/, torch at
-          # repo.amd.com/rocm/whl/<gfx>/), NOT the nightly single-RDNA build.
-          # ROCm 7.13 / torch 2.9.1 — a different code-object generation than the
-          # 7.14 nightly, which is the point of this validation run. Same robust
-          # install technique as nightly (legacy resolver + matched-torchvision
-          # repair), pointed at the stable sources.
-          # Pin the cp313 stable vLLM version (don't curl-discover): rocm.
-          # frameworks.amd.com WAF-403s a raw directory-listing GET from the
-          # runner's IP, but pip's PEP503 index access through --extra-index-url
-          # works. Bump this when AMD publishes a newer stable cp313 wheel at
-          # rocm.frameworks.amd.com/whl/gfx1151/vllm/ .
-          VLLM_VER="${{ github.event.inputs.stable_vllm_ver || '0.19.1.dev3+rocm7.13.0.g72ed2b398.d20260513' }}"
-          echo "stable: vLLM==$VLLM_VER"
-          # 1. Matched torch from the stable ROCm index (pulls rocm-sdk-* + triton
-          #    at the rocm7.13.0 ABI). The index carries torch 2.9.1 / 2.10.0 /
-          #    2.11.0 all at +rocm7.13.0; vLLM 0.19.1's own code guards pin it to
-          #    torch 2.9.x (>=2.9.0,<2.10.0), so use 2.9.1. NOTE: even this
-          #    code-correct version currently leaves unresolved c10::*[abi:cxx11]
-          #    symbols (tier0 T0.2) — AMD's stable vLLM wheel was built with a
-          #    different _GLIBCXX_USE_CXX11_ABI than its stable torch. That's an
-          #    upstream ABI skew the gate reports; we do not pin around it.
-          $VLLM_ROOT/bin/pip install --index-url "$TORCH_INDEX" \
-            --extra-index-url https://pypi.org/simple/ \
-            "torch==2.9.1+rocm7.13.0"
-          # 2. vLLM by version from the gfx index + PyPI for the ~70 normal deps.
-          #    Same legacy resolver as nightly (the recursion cycle is in vLLM's
-          #    graph regardless of channel); --ignore-requires-python guards any
-          #    amd-quark cp<3.13 cap.
-          ok=0
-          for attempt in 1 2 3; do
-            if pip_deep install --use-deprecated=legacy-resolver --ignore-requires-python \
-                 --extra-index-url "$VLLM_INDEX" \
-                 --extra-index-url "$TORCH_INDEX" \
-                 --extra-index-url https://pypi.org/simple/ \
-                 "vllm==$VLLM_VER"; then ok=1; break; fi
-            echo "::warning::stable vLLM install attempt $attempt failed; retry in $((attempt*10))s"
-            sleep $((attempt * 10))
-          done
-          [ "$ok" = 1 ] || { echo "::error::stable vLLM install failed after 3 attempts"; exit 1; }
-          # 3. Repair: the legacy resolver may have pulled a PyPI torchvision with
-          #    the wrong torch ABI (torchvision::nms unregistered -> import dies).
-          #    Force the matched ROCm build AFTER vLLM. pycountry is an undeclared
-          #    optional transitive (mistral_common). pip check surfaces the rest.
-          $VLLM_ROOT/bin/pip install --index-url "$TORCH_INDEX" \
-            --extra-index-url https://pypi.org/simple/ \
-            "torchvision==0.24.0+rocm7.13.0"
-          $VLLM_ROOT/bin/pip install pycountry
-          $VLLM_ROOT/bin/pip check || echo "::warning::pip check reported conflicts (see above); qualify will gate"
-        else
-          # NIGHTLY: repackage AMD's OFFICIAL nightly. AMD publishes a single
-          # universal RDNA vLLM wheel plus a date-stamped matched torch; we pair
-          # them by the shared ROCm build stamp (rocm7.14.0a<DATE>), so the set
-          # is ABI-consistent by construction — no pinning around mismatches.
-          # AMD publishes the nightly vLLM as TWO separate per-family lines,
-          # device-all-rdna and device-all-cdna, at independent versions. The
-          # line must therefore follow the matrix target, not be hardcoded.
-          # (torch does NOT: whl-multi-arch carries every arch, including
-          # rocm-sdk-device-gfx942/-gfx950, so the torch half is family-agnostic.)
-          case "${{ matrix.gfx_target }}" in
-            gfx942|gfx950) NIGHTLY_SET=device-all-cdna ;;
-            *)             NIGHTLY_SET=device-all-rdna ;;
-          esac
-          NIGHTLY_VLLM=https://rocm.frameworks-nightlies.amd.com/whl/$NIGHTLY_SET
-          NIGHTLY_TORCH=https://rocm.nightlies.amd.com/whl-multi-arch
-          echo "nightly vLLM line: $NIGHTLY_SET"
-          # torch's per-gfx kernels are an extra; map the matrix target to it.
-          case "${{ matrix.gfx_target }}" in
-            gfx1151) DEV=gfx1151 ;;
-            gfx1150) DEV=gfx1150 ;;
-            gfx110X) DEV=gfx1100 ;;
-            gfx120X) DEV=gfx1200 ;;
-            *) DEV="${{ matrix.gfx_target }}" ;;
-          esac
-          # 1. Use the version detect-nightly already resolved (so detect and
-          #    build agree even if AMD publishes a newer one mid-run); else
-          #    discover the newest cp314 wheel from the index.
-          # detect-nightly probes the RDNA line only (it gates the daily cron),
-          # so its version is valid for RDNA targets ONLY. Reusing it for a CDNA
-          # build would pin a version that does not exist on the CDNA line; leave
-          # it empty so the self-discovery below resolves from $NIGHTLY_VLLM.
-          if [ "$NIGHTLY_SET" = "device-all-rdna" ]; then
-            VLLM_VER="${{ needs.detect-nightly.outputs.vllm_ver }}"
-            ROCM_STAMP="${{ needs.detect-nightly.outputs.rocm_stamp }}"
-          else
-            VLLM_VER=""
-            ROCM_STAMP=""
-          fi
-          if [ -z "$VLLM_VER" ]; then
-            WHL=$(curl -fsSL "$NIGHTLY_VLLM/vllm/" \
-              | grep -oE 'vllm-[0-9][^"]*-cp314-cp314-linux_x86_64\.whl' \
-              | sort | tail -1)
-            VLLM_VER=$(echo "$WHL" | sed -E 's/^vllm-(.*)-cp314-cp314-linux_x86_64\.whl$/\1/' | sed 's/%2B/+/g')
-            ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
-          fi
-          [ -n "$VLLM_VER" ] || { echo "::error::no cp314 nightly vLLM version found"; exit 1; }
-          # Omni builds pin the qualified base (vLLM-Omni 0.23.0rc1 can't ride
-          # the latest nightly — see OMNI_BASE_VLLM_VER). Override the detected
-          # version so build/qualify/release all use the validated base.
-          if [ "$OMNI" = "true" ]; then
-            VLLM_VER="$OMNI_BASE_VLLM_VER"
-            ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
-            echo "omni: pinning base to $VLLM_VER (stamp $ROCM_STAMP)"
-          fi
-          # The torch ABI follows the vLLM WHEEL'S VERSION, so key the pin on
-          # $VLLM_VER (resolved above, after the omni override) — not on the
-          # nightly line. AMD advances its two lines independently: RDNA is on
-          # 0.25.x (torch 2.12 ABI) while CDNA is still on 0.23.1 (torch 2.11
-          # ABI), and whl-multi-arch carries BOTH torch builds at the same ROCm
-          # stamp, so a single global pin resolves and installs cleanly and then
-          # dies in qualify with unresolved torch::Library::_def symbols.
-          # Keying on the line (device-all-cdna -> 2.11) would fix today and
-          # silently re-break the day AMD moves CDNA to 0.25.x; keying on the
-          # version self-corrects. TV_VER moves with TORCH_VER — torchvision
-          # pairs strictly with torch (used by the repair step below) or
-          # torchvision::nms fails to register and `import vllm` dies.
-          case "$VLLM_VER" in
-            0.2[0-4].*) TORCH_VER=2.11.0; TV_VER=0.26.0 ;;
-            *)          TORCH_VER=2.12.0; TV_VER=0.27.0 ;;
-          esac
-          echo "nightly: vLLM==$VLLM_VER"
-          echo "nightly: torch=${TORCH_VER}+${ROCM_STAMP}[device-${DEV}]"
-          # 2. Matched torch + ROCm runtime libs + Triton + per-gfx kernels,
-          #    all resolved at the same ROCm stamp from one index.
-          $VLLM_ROOT/bin/pip install --index-url "$NIGHTLY_TORCH" \
-            --extra-index-url https://pypi.org/simple/ \
-            "torch[device-${DEV}]==${TORCH_VER}+${ROCM_STAMP}"
-          # 3a. Pre-install amd-quark. vLLM pins amd-quark>=0.8.99, but every
-          #    amd-quark >=0.7 on PyPI caps Requires-Python at <3.13 while our
-          #    nightly bundle is cp314. amd-quark is a pure-Python (py3-none-any) wheel —
-          #    the cap is a conservative untested-version guard, not a real ABI
-          #    limit — so install it ALONE with --ignore-requires-python (a tiny
-          #    candidate space). Scoping the flag here, not on the vLLM resolve,
-          #    is deliberate: passed globally it strips the Python filter from
-          #    every dep, ballooning pip's backtracking until it RecursionErrors.
-          #    Once installed and satisfying >=0.8.99, vLLM's resolve accepts it.
-          pip_deep install --ignore-requires-python "amd-quark>=0.8.99"
-          # 3b. The universal vLLM wheel + flash-attn (AMD index) + the rest from
-          #    PyPI. Install BY VERSION through the index (not a hand-built wheel
-          #    URL): the host serves the wheel only at its %2B-encoded path, so a
-          #    direct URL with a literal '+' gets WAF-403'd. Letting pip resolve
-          #    the index href fetches the correctly-encoded URL. vLLM declares no
-          #    torch dep, so the matched torch above is untouched.
-          #    Two flags, both required and complementary:
-          #    --use-deprecated=legacy-resolver: the new resolvelib resolver
-          #    RecursionErrors building its result graph on a cycle in vLLM's
-          #    dependency closure (resolution.py:_has_route_to_root recurses
-          #    without end). The legacy resolver doesn't walk that graph. (pip is
-          #    pinned to 24.3.1 above so this flag still exists.)
-          #    --ignore-requires-python: the legacy resolver re-checks
-          #    requires-python on the already-installed amd-quark (capped <3.13)
-          #    and hard-errors on cp314; the flag makes it accept it. On
-          #    the legacy (first-found, no-backtrack) resolver this can't balloon
-          #    the candidate search the way it would on the new resolver.
-          ok=0
-          for attempt in 1 2 3; do
-            if pip_deep install --use-deprecated=legacy-resolver --ignore-requires-python \
-                 --extra-index-url "$NIGHTLY_VLLM" \
-                 --extra-index-url https://pypi.org/simple/ \
-                 "vllm==$VLLM_VER"; then ok=1; break; fi
-            echo "::warning::vLLM install attempt $attempt failed; retry in $((attempt*10))s"
-            sleep $((attempt * 10))
-          done
-          [ "$ok" = 1 ] || { echo "::error::vLLM install failed after 3 attempts"; exit 1; }
-          # 3c. Repair legacy-resolver over-picks. The legacy resolver takes the
-          #    first-found version and ignores transitive UPPER bounds / ABI, so
-          #    it leaves deps that break vLLM at import (each caught by qualify
-          #    T1.5). Re-assert the correct ones here (small single-package
-          #    resolves — no cycle), then `pip check` surfaces any remaining
-          #    mis-pick in the build log without failing the build (qualify gates).
-          #
-          #    torchvision must match the ROCm torch ABI or its C++ ops
-          #    (torchvision::nms) fail to register and `import vllm` dies. Legacy
-          #    pulled a PyPI torchvision built against a different torch; force the
-          #    matched ROCm build from the nightly index, same rocm stamp.
-          #    TV_VER is set alongside TORCH_VER above — they pair strictly.
-          $VLLM_ROOT/bin/pip install --index-url "$NIGHTLY_TORCH" \
-            --extra-index-url https://pypi.org/simple/ \
-            "torchvision==${TV_VER}+${ROCM_STAMP}"
-          #    transformers needs tokenizers>=0.22.0,<=0.23.0 but legacy pulled
-          #    0.23.1, raising ImportError at import; pin it back into range.
-          $VLLM_ROOT/bin/pip install "tokenizers>=0.22.0,<=0.23.0"
-          #    pycountry: an OPTIONAL transitive nothing declares as a hard dep
-          #    (vLLM -> mistral_common -> pydantic_extra_types.language_code ->
-          #    pycountry), so no resolver installs it, yet mistral_common imports
-          #    it at module load and vllm-server dies without it. Add explicitly.
-          $VLLM_ROOT/bin/pip install pycountry
-          $VLLM_ROOT/bin/pip check || echo "::warning::pip check reported dependency conflicts (see above); qualify will gate"
-        fi
-
-        # Use the AMD pip ROCm SDK amdsmi (_rocm_sdk_core/share/amd_smi) rather
-        # than any amdsmi the wheels bundled.
-        rm -rf $SP/amdsmi $SP/amdsmi-*.dist-info
-
-        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
-          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        export LD_LIBRARY_PATH
-        # Report versions but DO NOT fail the build on a bad combination — a
-        # broken bundle must still be packaged so the qualification gate can
-        # detect and REPORT it. Fixing upstream is never our job.
-        $VLLM_ROOT/bin/python3 -c "
-        import torch; print(f'PyTorch {torch.__version__}')
-        import vllm; print(f'vLLM {vllm.__version__}')
-        " || echo "WARNING: import check failed — qualification will report this"
-
-    - name: Pre-compile Triton HIP utilities (eliminates gcc dependency)
-      run: |
-        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
-        TRITON_AMD="$SP/triton/backends/amd"
-        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
-          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        export LD_LIBRARY_PATH
-
-        # Create unversioned symlinks for ROCm libs (pip installs only have versioned .so.N)
-        ROCM_LIB="$SP/_rocm_sdk_core/lib"
-        for lib in "$ROCM_LIB"/*.so.*; do
-          name=$(basename "$lib")
-          link="$ROCM_LIB/${name%%.*}.so"
-          [ ! -e "$link" ] && ln -sf "$name" "$link"
-        done
-        ls -la "$ROCM_LIB/libamdhip64.so" || echo "WARNING: symlink not created"
-
-        # Compile the hip_utils C module with gcc directly and save into the package.
-        # We can't use Triton's compile_module_from_src because it also tries to
-        # dlopen the HIP library, which doesn't work on headless CI.
-        TRITON_AMD="$SP/triton/backends/amd"
-        PYTHON_INC="$VLLM_ROOT/include/python${PYVER}"
-
-        # Generate the C source with the HIP library path baked in
-        $VLLM_ROOT/bin/python3 -c "
-        from pathlib import Path
-        import os
-        dirname = '$TRITON_AMD'
-        src = Path(os.path.join(dirname, 'driver.c')).read_text()
-        # Bake in the relative path that will resolve at runtime via LD_LIBRARY_PATH
-        src = src.replace('/*py_libhip_search_path*/', 'libamdhip64.so', 1)
-        Path('/tmp/hip_utils.c').write_text(src)
-        print('Generated /tmp/hip_utils.c')
-        "
-
-        # Compile with gcc
-        gcc /tmp/hip_utils.c -O3 -shared -fPIC -Wno-psabi \
-          -o "$TRITON_AMD/hip_utils_prebuilt.so" \
-          -I"$TRITON_AMD/include" \
-          -I"$PYTHON_INC"
-        echo "Pre-compiled: $TRITON_AMD/hip_utils_prebuilt.so ($(stat -c%s "$TRITON_AMD/hip_utils_prebuilt.so") bytes)"
-
-        # Patch Triton to load the pre-built .so instead of JIT-compiling
-        DRIVER_PY="$TRITON_AMD/driver.py"
-        sed -i 's|mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|_pso = os.path.join(dirname, "hip_utils_prebuilt.so")\n        if os.path.exists(_pso):\n            import importlib.util as _ilu\n            _sp = _ilu.spec_from_file_location("hip_utils", _pso)\n            mod = _ilu.module_from_spec(_sp)\n            _sp.loader.exec_module(mod)\n        else:\n            mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|' "$DRIVER_PY"
-        $VLLM_ROOT/bin/python3 -c "import ast; ast.parse(open('$DRIVER_PY').read()); print('Patched driver.py — syntax OK')"
-
-    - name: Create launcher script
-      run: |
-        cat > $VLLM_ROOT/bin/vllm-server << 'LAUNCHER_EOF'
-        #!/bin/bash
-        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        VENV_DIR="$(dirname "$SCRIPT_DIR")"
-        # Glob the bundled python3.* dir so the launcher is Python-version-agnostic
-        # (the bundle is cp313 or cp314 depending on channel).
-        SP="$(echo "$VENV_DIR"/lib/python3.*/site-packages)"
-        # Add all bundled ROCm library paths
-        for libdir in "$SP"/_rocm_sdk_*/lib "$SP"/torch/lib; do
-        [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        # Also add LLVM lib for the bundled clang
-        LD_LIBRARY_PATH="$SP/_rocm_sdk_core/lib/llvm/lib:${LD_LIBRARY_PATH}"
-        export LD_LIBRARY_PATH
-        export PYTHONPATH="$SP/_rocm_sdk_core/share/amd_smi:${PYTHONPATH:-}"
-        export FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
-        # Use bundled clang for Triton JIT (no system gcc needed)
-        CLANG="$SP/_rocm_sdk_core/lib/llvm/bin/clang"
-        [ -f "$CLANG" ] && chmod +x "$CLANG" "$CLANG"-* 2>/dev/null
-        export CC="$CLANG"
-        exec "$SCRIPT_DIR/python3" -m vllm.entrypoints.openai.api_server "$@"
-        LAUNCHER_EOF
-
-        # Remove YAML indentation from heredoc
-        sed -i 's/^        //' $VLLM_ROOT/bin/vllm-server
-        chmod +x $VLLM_ROOT/bin/vllm-server
-        echo "Launcher script:"
-        cat $VLLM_ROOT/bin/vllm-server
-
-    - name: Strip unnecessary files to reduce size
-      run: |
-        cd $VLLM_ROOT
-        echo "=== Size before cleanup ==="
-        du -sh .
-
-        SP="lib/python${PYVER}/site-packages"
-
-        # Remove pip/wheel (keep setuptools — torch.utils.cpp_extension needs it)
-        rm -rf $SP/pip* $SP/wheel* 2>/dev/null || true
-
-        # Remove __pycache__ and .pyc
-        find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-        find . -name "*.pyc" -delete 2>/dev/null || true
-
-        # Remove test/benchmark dirs (but NOT torch.testing — it's imported at runtime)
-        rm -rf $SP/torch/test $SP/torch/benchmarks 2>/dev/null || true
-
-        # Remove packages not needed for inference serving (~500MB)
-        rm -rf $SP/pyarrow* $SP/opencv* $SP/cv2* 2>/dev/null || true
-        rm -rf $SP/onnx* $SP/pandas* $SP/plotly* 2>/dev/null || true
-        rm -rf $SP/datasets* $SP/evaluate* $SP/peft* $SP/timm* 2>/dev/null || true
-        rm -rf $SP/boto3* $SP/botocore* $SP/s3transfer* 2>/dev/null || true
-        rm -rf $SP/azure* $SP/google_cloud* $SP/google_auth* $SP/msal* 2>/dev/null || true
-        rm -rf $SP/tensorizer* $SP/runai* 2>/dev/null || true
-        rm -rf $SP/aiter_meta* 2>/dev/null || true
-
-        # Trim LLVM toolchain: keep only clang + its libs (~350MB saved)
-        LLVM="$SP/_rocm_sdk_core/lib/llvm"
-        # Keep the clang driver and its versioned binary (clang-NN). The LLVM
-        # major tracks the ROCm release (clang-22 on 7.13, clang-23 on 7.14);
-        # hardcoding clang-22 would delete the real compiler on newer ROCm and
-        # break Triton's runtime JIT. Match clang-* so it survives any version.
-        find "$LLVM/bin" -type f ! -name "clang" ! -name "clang-*" -delete 2>/dev/null || true
-        find "$LLVM/bin" -type l ! -name "clang" -delete 2>/dev/null || true
-        # Keep only libs that clang needs (libclang-cpp, libLLVM, rocm_sysdeps)
-        find "$LLVM/lib" -name "*.so*" \
-          ! -name "libclang-cpp*" \
-          ! -name "libLLVM*" \
-          -delete 2>/dev/null || true
-        rm -rf "$LLVM/lib/clang/"*/include/cuda_wrappers 2>/dev/null || true
-
-        # Trim ROCm SDK bin/ (Python wrapper scripts, not needed)
-        rm -rf "$SP/_rocm_sdk_core/bin" 2>/dev/null || true
-
-        # Remove Python stdlib we don't need
-        rm -rf lib/python${PYVER}/test lib/python${PYVER}/tkinter lib/python${PYVER}/idlelib 2>/dev/null || true
-        rm -rf lib/python${PYVER}/turtledemo lib/python${PYVER}/ensurepip 2>/dev/null || true
-        # Keep include/ — Triton JIT needs Python.h headers
-
-        # Ensure bundled clang is executable (permissions lost during tar)
-        chmod +x "$LLVM/bin/clang"* 2>/dev/null || true
-
-        # NOTE: Do NOT strip .so files — AMD ROCm wheels use special ELF
-        # alignment that strip corrupts, and numpy/scipy also break.
-
-        echo "=== Size after cleanup ==="
-        du -sh .
-        echo ""
-        echo "Top consumers:"
-        du -sh $SP/torch/ $SP/vllm/ $SP/_rocm_sdk_core/ $SP/aiter/ $SP/triton/ 2>/dev/null || true
-
-    - name: Layer vLLM-Omni onto the bundle (omni builds only)
-      # MUST run AFTER the Strip step: Strip deletes opencv/onnx/peft/timm (and
-      # pip) — exactly the deps the omni layer reinstalls. build_omni_layer.sh
-      # re-bootstraps pip and pulls vllm-omni + its runtime/multimodal deps + an
-      # ABI-matched torchaudio. torchaudio must come from the SAME ROCm index as
-      # the bundled torch: per-gfx stable index on the stable channel, AMD's
-      # multi-arch nightly index on nightly.
-      if: ${{ env.OMNI == 'true' }}
-      env:
-        TORCH_INDEX: ${{ env.CHANNEL == 'stable' && steps.wheel-urls.outputs.torch_index || 'https://rocm.nightlies.amd.com/whl-multi-arch' }}
-      run: |
-        bash scripts/build_omni_layer.sh
-
-    - name: Make console-script shebangs relocatable
-      # pip records the build-time interpreter path in every console script it
-      # generates, so on a consumer machine execve() fails and reports the
-      # SCRIPT as missing rather than the interpreter. Rewrite the shebang to
-      # resolve the interpreter next to the script. The replacement is valid sh
-      # and a no-op string expression in Python, so the scripts still parse.
-      # Matches ANY absolute python-interpreter shebang (not just $VLLM_ROOT/bin:
-      # wheels can record foreign build prefixes like /opt/vllm), including
-      # distlib's quoted form (#!"/path with spaces/python3") and interpreter
-      # options (#!/path/python3 -u), which are re-emitted after the resolved
-      # interpreter. A PEP 263 coding cookie on line 2 is carried forward so it
-      # stays within the two lines Python scans. __doc__ is reset to None so the
-      # trampoline text never leaks into argparse(description=__doc__).
-      # Completeness gate: after the pass, re-scan and FAIL if any absolute
-      # python shebang remains ("no build-time shebangs remain", not "at least
-      # one was fixed"), then compile() every rewritten file as a parse check.
-      run: |
-        : "${VLLM_ROOT:?VLLM_ROOT is unset -- refusing to guess the bundle path}"
-        python3 - "$VLLM_ROOT/bin" <<'PYEOF'
-        import os, re, stat, sys
-        from pathlib import Path
-
-        bindir = Path(sys.argv[1])
-        name_re = re.compile(rb"^python[0-9]*(\.[0-9]+)*$")  # not python3-config
-        coding_re = re.compile(rb"^[ \t\f]*#.*?coding[:=][ \t]*[-_.a-zA-Z0-9]+")
-
-        def parse_shebang(first):
-            """(interpreter, [options]) for an absolute-path shebang, else (None, None)."""
-            body = first[2:].rstrip(b"\r").strip()
-            if body.startswith(b'"'):
-                end = body.find(b'"', 1)
-                if end < 0:
-                    return None, None
-                return body[1:end], body[end + 1:].split()
-            fields = body.split()
-            if not fields or not fields[0].startswith(b"/"):
-                return None, None
-            return fields[0], fields[1:]
-
-        def python_shebang(first):
-            interp, opts = parse_shebang(first)
-            if interp is None or not name_re.match(os.path.basename(interp)):
-                return None, None
-            return interp, opts
-
-        fixed = []
-        for path in sorted(bindir.iterdir()):
-            if not path.is_file() or path.is_symlink():
-                continue
-            first, _, rest = path.read_bytes().partition(b"\n")
-            if not first.startswith(b"#!"):
-                continue
-            interp, opts = python_shebang(first)
-            if interp is None:
-                continue
-            name = os.path.basename(interp)
-            cookie = b""
-            rest_first, _, rest_tail = rest.partition(b"\n")
-            if coding_re.match(rest_first):
-                cookie = rest_first + b"\n"
-                rest = rest_tail
-            optstr = b" " + b" ".join(opts) if opts else b""
-            # A statement before `from __future__` is a SyntaxError (the polyglot
-            # DOCSTRING before it is legal) -- caught by the compile() gate on the
-            # real bundle (numba). Those few scripts keep the trampoline as
-            # __doc__; everything else gets None.
-            doc_reset = b"" if b"from __future__" in rest else b"__doc__ = None\n"
-            mode = path.stat().st_mode
-            path.write_bytes(
-                b"#!/bin/sh\n" + cookie
-                + b"'''exec' \"$(dirname \"$(readlink -f \"$0\")\")/" + name + b"\""
-                + optstr + b" \"$0\" \"$@\"\n"
-                b"' '''\n"
-                + doc_reset + rest
-            )
-            os.chmod(path, stat.S_IMODE(mode))
-            fixed.append(path)
-
-        print("rewrote %d console-script shebangs" % len(fixed))
-        if not fixed:
-            sys.exit("error: rewrote nothing -- refusing to ship an unchecked bundle")
-
-        leftover = []
-        for path in sorted(bindir.iterdir()):
-            if not path.is_file() or path.is_symlink():
-                continue
-            first = path.read_bytes().partition(b"\n")[0]
-            if first.startswith(b"#!") and python_shebang(first)[0] is not None:
-                leftover.append(path.name)
-        if leftover:
-            sys.exit("error: build-time python shebangs remain after the pass: %s"
-                     % ", ".join(leftover))
-
-        for path in fixed:
-            try:
-                compile(path.read_bytes(), str(path), "exec")
-            except SyntaxError as e:
-                sys.exit("error: rewritten script no longer parses: %s: %s" % (path, e))
-        print("verified: 0 absolute python shebangs remain; %d rewritten scripts compile"
-              % len(fixed))
-        PYEOF
-
-    - name: Verify bundled environment works
-      run: |
-        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
-        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
-          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        export LD_LIBRARY_PATH
-
-        $VLLM_ROOT/bin/python3 -c "import vllm; print(f'vLLM {vllm.__version__} OK')"
-        $VLLM_ROOT/bin/python3 -c "import torch; print(f'PyTorch {torch.__version__} OK')"
-        $VLLM_ROOT/bin/python3 -c "
-        # Verify native extensions exist (they load only with GPU present)
-        import os, pathlib
-        sp = pathlib.Path('$SP/vllm')
-        for ext in ['_C.abi3.so', '_rocm_C.abi3.so']:
-            p = sp / ext
-            assert p.exists(), f'Missing {ext}'
-            print(f'{ext}: {p.stat().st_size // 1048576} MB')
-        print('Native extensions verified')
-        "
-        bash -n $VLLM_ROOT/bin/vllm-server
-        # Execute one REWRITTEN console script for real -- python3 -c above runs
-        # the interpreter directly and bash -n checks the untouched wrapper, so
-        # neither would notice all ~113 rewritten scripts being dead. This
-        # exercises the sh trampoline end-to-end (a full sh -n cannot: sh parses
-        # a polyglot past the exec line into the Python body).
-        #
-        # Pick the probe at runtime rather than hardcoding a name: the Strip step
-        # removes $SP/pip* (and build_omni_layer.sh re-strips it), so bin/pip is a
-        # DANGLING console script -- probing it fails with ModuleNotFoundError on
-        # every build, which says nothing about the trampoline. Candidates below
-        # are ordered by how certain their module is to survive the strip; torch
-        # and vllm are the bundle's reason to exist and are never trimmed.
-        probe=""
-        for cand in torchrun vllm isympy f2py normalizer; do
-          [ -x "$VLLM_ROOT/bin/$cand" ] || continue
-          # Confirm the module behind it survived the strip before relying on it.
-          if "$VLLM_ROOT/bin/$cand" --help >/dev/null 2>&1; then probe="$cand"; break; fi
-        done
-        if [ -z "$probe" ]; then
-          echo "::error::no rewritten console script could be executed -- the sh trampoline may be broken"
-          ls -1 "$VLLM_ROOT/bin" | head -40
-          exit 1
-        fi
-        echo "trampoline probe OK: bin/$probe launched the bundled interpreter"
-        echo "All sanity checks passed"
-
-    - name: Report final size
-      run: |
-        echo "=== Final artifact ==="
-        du -sh $VLLM_ROOT/
-        echo ""
-        du -sh $VLLM_ROOT/*/ 2>/dev/null
-
-    - name: Create release archive
-      run: |
-        # tar.gz preserves the ROCm symlinks (upload-artifact's zip expands each
-        # symlink into a full copy of its target, bloating the artifact). tar
-        # also keeps the hidden per-gfx GPU code-object dirs (torch/.kpack/,
-        # _rocm_sdk_*/.kpack/, .devel_links/) that ROCm wheels ship, so
-        # include-hidden-files is no longer needed.
-        ARCHIVE="$RUNNER_TEMP/vllm-ubuntu-rocm-${{ matrix.gfx_target }}-x64.tar.gz"
-        tar -czf "$ARCHIVE" -C "$VLLM_ROOT" .
-        echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
-        echo "Created $(du -h "$ARCHIVE" | cut -f1) archive"
-
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+    - name: Build the bundle
+      id: build
+      uses: ./.github/actions/build-vllm-bundle
       with:
-        name: vllm-ubuntu-rocm-${{ matrix.gfx_target }}-x64
-        # Upload the intermediate tar.gz (not the raw bundle), so the artifact
-        # preserves symlinks and the hidden per-gfx code-object dirs on download.
-        path: ${{ env.ARCHIVE }}
-        retention-days: 30
-        compression-level: 6
-
-    - name: Set job outputs
-      id: set-outputs
-      run: |
-        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
-        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
-          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        export LD_LIBRARY_PATH
-
-        vllm_ver=$($VLLM_ROOT/bin/python3 -c "import vllm; print(vllm.__version__)")
-        torch_ver=$($VLLM_ROOT/bin/python3 -c "import torch; print(torch.__version__)")
-        echo "vllm_version=$vllm_ver" >> $GITHUB_OUTPUT
-        echo "torch_version=$torch_ver" >> $GITHUB_OUTPUT
-        # Empty on non-omni builds. Read from dist-info (no heavy import) so the
-        # create-release tag can distinguish vllm-omni* artifacts.
-        omni_ver=$(ls -d "$SP"/vllm_omni-*.dist-info 2>/dev/null | head -1 \
-          | sed -E 's#.*/vllm_omni-(.*)\.dist-info#\1#')
-        echo "omni_version=$omni_ver" >> $GITHUB_OUTPUT
-
-    - name: Clean up
-      if: always()
-      run: |
-        # No sudo — it's under the runner's temp dir. Free the box for the next run.
-        rm -rf "$RUNNER_TEMP/vllm-build" || true
+        gfx_target: ${{ matrix.gfx_target }}
+        # The release path's artifact name, unchanged: create-release and
+        # qualify both resolve this exact string.
+        artifact_name: vllm-ubuntu-rocm-${{ matrix.gfx_target }}-x64
+        retention_days: '30'
+        channel: ${{ env.CHANNEL }}
+        omni: ${{ env.OMNI }}
+        omni_base_vllm_ver: ${{ env.OMNI_BASE_VLLM_VER }}
+        vllm_ver: ${{ needs.detect-nightly.outputs.vllm_ver }}
+        rocm_stamp: ${{ needs.detect-nightly.outputs.rocm_stamp }}
+        stable_vllm_ver: ${{ github.event.inputs.stable_vllm_ver }}
 
   # 16-test qualification, one leg per selected target that has qualification
   # hardware (prepare-matrix qualify_matrix: target -> self-hosted runner group;
@@ -943,8 +330,6 @@ jobs:
     runs-on:
       group: ${{ matrix.runner_group }}
       labels: [self-hosted, Linux]
-    env:
-      GFX: ${{ matrix.gfx }}
     # Runs on release builds AND on omni dispatches (omni is experimental —
     # always qualify it, even as a no-publish dry run; release stays gated on
     # create_release in the create-release job). Skips PRs and dispatches whose
@@ -968,174 +353,44 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Download ${{ matrix.gfx }} artifact
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        set -euo pipefail
-        WORK="${{ runner.temp }}/vllm-qual"
-        DEST="$WORK/vllm"
-        ZIP="$WORK/artifact.zip"
-        mkdir -p "$DEST"
-        echo "=== Disk before download ==="; df -h "$WORK" || true
-
-        # The build artifact is ~3.3 GB (extracts to ~11 GB). actions/download-artifact@v4
-        # is unreliable for artifacts this size on self-hosted runners, so pull the
-        # artifact zip directly with curl (streams to disk, resumable), unzip it to
-        # recover the release tar.gz, then untar it below.
-        # Resolve the artifact id via the REST API with curl + python3 — the box
-        # does not have the gh CLI installed.
-        ART_ID=$(curl -fsSL \
-                   -H "Authorization: Bearer $GH_TOKEN" \
-                   -H "Accept: application/vnd.github+json" \
-                   "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-                 | python3 -c "import sys,json,os; print(next((a['id'] for a in json.load(sys.stdin)['artifacts'] if a['name']==f\"vllm-ubuntu-rocm-{os.environ['GFX']}-x64\"), ''))")
-        [ -n "$ART_ID" ] || { echo "::error::${GFX} artifact not found for this run"; exit 1; }
-        echo "Artifact id: $ART_ID"
-
-        avail_gb=$(df -BG --output=avail "$WORK" | tail -1 | tr -dc '0-9')
-        echo "Available space: ${avail_gb} GB"
-        if [ "${avail_gb:-0}" -lt 15 ]; then
-          echo "::error::Only ${avail_gb} GB free on the runner; need ~15 GB for the 11 GB build."
-          exit 1
-        fi
-
-        ok=0
-        for attempt in 1 2 3; do
-          echo "=== curl attempt $attempt ==="
-          if curl -fL --retry 5 --retry-delay 10 --retry-all-errors -C - \
-                  -H "Authorization: Bearer $GH_TOKEN" \
-                  -H "Accept: application/vnd.github+json" \
-                  -o "$ZIP" \
-                  "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${ART_ID}/zip"; then
-            ok=1; break
-          fi
-          echo "attempt $attempt failed; retrying in 15s"; sleep 15
-        done
-        [ "$ok" = "1" ] || { echo "::error::artifact zip download failed after 3 attempts"; df -h "$WORK" || true; exit 1; }
-        echo "Downloaded zip: $(du -h "$ZIP" | cut -f1)"
-
-        echo "=== Extracting ==="
-        # The artifact now holds the release tar.gz (not the raw bundle contents):
-        # unzip it, then untar so $DEST is the bundle root (bin/, lib/, ...).
-        # tar.gz preserves the ROCm symlinks the zip previously dropped.
-        if command -v unzip >/dev/null 2>&1; then
-          unzip -q -o "$ZIP" -d "$WORK/raw"
-        else
-          python3 -m zipfile -e "$ZIP" "$WORK/raw"
-        fi
-        rm -f "$ZIP"   # reclaim space immediately
-        TARBALL=$(find "$WORK/raw" -name '*.tar.gz' | head -n1)
-        [ -n "$TARBALL" ] || { echo "::error::no release archive in ${GFX} artifact"; exit 1; }
-        tar -xzf "$TARBALL" -C "$DEST"
-        rm -rf "$WORK/raw"
-        echo "Extracted $(du -sh "$DEST" | cut -f1) to $DEST"
-        echo "=== Disk after extract ==="; df -h "$WORK" || true
-
-    - name: Restore permissions and ROCm symlinks
-      run: |
-        # The artifact zip wraps a single tar.gz whose tar -xzf restores modes
-        # and the unversioned .so symlinks, so this is a defensive backstop
-        # (older raw-file artifacts lost +x), not a required repair.
-        ROOT="${{ runner.temp }}/vllm-qual/vllm"
-        # The bundle's Python version is channel-dependent (cp313 stable / cp314
-        # nightly); glob it rather than hardcode.
-        SP="$(echo "$ROOT"/lib/python3.*/site-packages)"
-        chmod +x "$ROOT/bin/"* 2>/dev/null || true
-        chmod +x "$SP/_rocm_sdk_core/lib/llvm/bin/"clang* 2>/dev/null || true
-        ROCM_LIB="$SP/_rocm_sdk_core/lib"
-        for lib in "$ROCM_LIB"/*.so.*; do
-          [ -e "$lib" ] || continue
-          name=$(basename "$lib"); link="$ROCM_LIB/${name%%.*}.so"
-          # Use `if` (not `&&`) so a pre-existing symlink doesn't leave the loop
-          # with exit 1 and trip `set -e`. The artifact preserves these symlinks,
-          # so this is now mostly a defensive no-op.
-          if [ ! -e "$link" ]; then ln -sf "$name" "$link"; fi
-        done
-
-    - name: Run 16-test qualification (tier0 + tier1 + tier2)
-      id: qual
-      run: |
-        WORK="${{ runner.temp }}/vllm-qual"
-        ROOT="$WORK/vllm"
-        PY="$ROOT/bin/python3"
-        FRAG="$WORK/fragments"; mkdir -p "$FRAG"
-        Q="$GITHUB_WORKSPACE/scripts/qualify"
-        TAG="vllm${{ needs.build-ubuntu.outputs.vllm_version }}-${GFX}"
-        # Omni builds qualify the omni serving path and record an omni candidate tag.
-        if [ "$OMNI" = "true" ]; then
-          TAG="vllm-omni${{ needs.build-ubuntu.outputs.omni_version }}-${GFX}"
-        fi
-
-        # The tiers are run WITHOUT --fail-on-error so all 16 tests execute and
-        # emit a JSON fragment even when one fails; `aggregate --fail-on-no-promote`
-        # is the single gate that decides pass/fail for the whole job.
-        echo "::group::Tier 0 — static bundle verification (T0.1–T0.6)"
-        "$PY" "$Q/tier0_static.py"   --bundle-root "$ROOT" --gfx-target "$GFX" \
-            --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier0-report.json" || true
-        echo "::endgroup::"
-
-        echo "::group::Tier 1 — hardware smoke (T1.1–T1.5)"
-        "$PY" "$Q/tier1_smoke.py"    --bundle-root "$ROOT" --gfx-target "$GFX" \
-            --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier1-report.json" || true
-        echo "::endgroup::"
-
-        # Tier 2 functional inference. Omni bundles run the omni serving path
-        # (vllm-omni-server + single-GPU deploy config) instead of plain vLLM;
-        # both emit a `tier2` fragment so the aggregate require-tiers rule is
-        # identical. The two are mutually exclusive per run.
-        if [ "$OMNI" = "true" ]; then
-          echo "::group::Tier 2 (omni) — functional inference via vllm-omni-server"
-          "$PY" "$Q/tier2_omni.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
-              --channel "$CHANNEL" --candidate-tag "$TAG" --logs-dir "$FRAG" \
-              --output "$FRAG/tier2-report.json" || true
-          echo "::endgroup::"
-        else
-          echo "::group::Tier 2 — functional inference (T2.1–T2.5)"
-          "$PY" "$Q/tier2_inference.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
-              --channel "$CHANNEL" --candidate-tag "$TAG" \
-              --model Qwen/Qwen2.5-0.5B-Instruct --logs-dir "$FRAG" \
-              --output "$FRAG/tier2-report.json" || true
-          echo "::endgroup::"
-        fi
-
-        echo "=== Aggregate fragments → qualification report (gates the job) ==="
-        "$PY" "$Q/aggregate.py" --fragments-dir "$FRAG" --gfx-target "$GFX" \
-            --channel "$CHANNEL" --candidate-tag "$TAG" \
-            --require-tiers tier0,tier1,tier2 --hardware-validated \
-            --output "$FRAG/qualification-report.json" \
-            --fail-on-no-promote
-
-    - name: Upload qualification report and fragments
-      if: always()
-      uses: actions/upload-artifact@v4
+    - name: Qualify the bundle
+      id: qualify
+      uses: ./.github/actions/qualify-vllm-bundle
       with:
-        name: qualification-${{ matrix.gfx }}
-        path: |
-          ${{ runner.temp }}/vllm-qual/fragments/*.json
-          ${{ runner.temp }}/vllm-qual/fragments/*.log
-        if-no-files-found: warn
-
-    - name: Tear down and clean up
-      if: always()
-      run: |
-        # Free the GPU on this persistent runner no matter how the harness ended.
-        WORK="${{ runner.temp }}/vllm-qual"
-        pkill -9 -f "vllm.entrypoints.openai.api_server" 2>/dev/null || true
-        rm -rf "$WORK" || true
+        gfx: ${{ matrix.gfx }}
+        build_artifact: vllm-ubuntu-rocm-${{ matrix.gfx }}-x64
+        # publish-qualification globs `qualification-*`; this is the name it
+        # is meant to pick up.
+        report_artifact_name: qualification-${{ matrix.gfx }}
+        channel: ${{ env.CHANNEL }}
+        omni: ${{ env.OMNI }}
+        vllm_version: ${{ needs.build-ubuntu.outputs.vllm_version }}
+        omni_version: ${{ needs.build-ubuntu.outputs.omni_version }}
 
   # ==========================================================================
   # The same build and the same qualification, on the AMD DevLab ephemeral pool
   #
-  # Copies of build-ubuntu and qualify pinned to the ephemeral pool -- which
-  # provisions a Strix Halo (gfx1151) VM per job and destroys it afterwards --
-  # and chained to each other rather than into the release path. They run
-  # alongside the dev_lab jobs, never in place of them.
+  # These two jobs call the SAME composite actions the dev_lab jobs above call.
+  # That is the whole design: the ephemeral pool is a different place to run
+  # the steps, not a different set of steps. Between #30, #32 and #33 those
+  # steps changed four times in one week, so a copy would have been stale
+  # before it landed -- and would have gone red for reasons that have nothing
+  # to do with this pool.
+  #
+  # The pool provisions a Strix Halo (gfx1151) VM per job from a golden image
+  # and destroys it afterwards, so each run starts from a known state.
+  #
+  # runs-on is bare labels with no `group:` on purpose. These runners are
+  # registered to the repo, and a repo-registered runner is always in the
+  # repo's Default group -- `group:` can never select it. 'strix-halo' and
+  # 'ephemeral' are the specific labels the orchestrator publishes; the pool
+  # deliberately refuses jobs that name only generic labels, so a bare
+  # [self-hosted, Linux] would not reach it.
   #
   # Two things differ beyond runs-on, both deliberate:
   #
-  #   gfx1151 only. That is the silicon this pool has. The other targets in the
-  #   release matrix have no ephemeral hardware to build for.
+  #   gfx1151 only. That is the silicon this pool has, and it comes from the
+  #   same QUALIFICATION_POOLS registry that drives the dev_lab legs.
   #
   #   No dedup gate. The release path skips a build when detect-nightly says
   #   the wheel has already been qualified. That is right for a shared box and
@@ -1145,738 +400,82 @@ jobs:
   # Nothing in the release path can see them: they need each other and not
   # build-ubuntu, publish-qualification still needs qualify, create-release is
   # still gated on qualify, and both artifacts are prefixed ephemeral- so they
-  # fall outside every name and pattern the release jobs resolve. Ephemeral
-  # artifacts keep 7 days rather than 30 -- an 11 GB bundle rebuilt daily is
-  # not worth a month of storage when nothing downstream reads it.
+  # fall outside every name and glob the release jobs resolve. continue-on-error
+  # plus no downstream needs means a red soak leg cannot fail the workflow or
+  # block a release. Ephemeral artifacts keep 7 days rather than 30 -- an 11 GB
+  # bundle rebuilt daily is not worth a month when nothing downstream reads it.
   #
-  # The trade: this chain builds its own bundle, so the comparison is
-  # whole-path against whole-path rather than two runners over one artifact.
-  # That is the price of exercising the build here too, and the build is the
-  # half that would otherwise never run on this pool at all.
-  #
-  # When the dev_lab box is decommissioned: delete build-ubuntu and qualify,
-  # drop the -ephemeral suffixes, restore the dedup gate and the full matrix,
-  # and repoint publish-qualification and create-release. To call the trial
-  # off: delete these two jobs.
+  # To call the trial off: delete these two jobs and the 'ephemeral' entry in
+  # QUALIFICATION_POOLS. Nothing else refers to them.
   # ==========================================================================
   build-ubuntu-ephemeral:
-    # Target the dev_lab runner GROUP explicitly, not just labels. The org's
-    # Default group is visibility:all, so a bare [self-hosted, Linux] also
-    # matches Linux boxes in other groups (stx / sjlab / Default) the repo can
-    # see — runs landed on a non-dev_lab box. `group: dev_lab` + the Linux label
-    # selects only the dev_lab Linux box (currently ta-devlab-halo-03) with no
-    # name-pin, so it survives re-image/rename as long as the box stays in the
-    # group. AMD's frameworks-nightlies host allowlists these boxes' egress but
-    # 403s GitHub-hosted runner IPs, so the nightly vLLM wheel must be fetched
-    # here. Build needs only network + pip (no GPU); it shares the box with
-    # qualify, which runs after via `needs`.
     runs-on: [self-hosted, Linux, strix-halo, ephemeral]
-    continue-on-error: true
     needs: [prepare-matrix, detect-nightly]
-    # Deliberately NOT gated on detect-nightly's dedup, unlike the release
-    # build above. Skipping when the nightly has already been qualified is
-    # right for a shared box and wrong for a pool being soaked: it would
-    # idle this job on every day AMD does not publish, which is most days.
-    # This runs on every schedule and every dispatch. PRs stay excluded --
-    # an 11 GB build per push is not what anyone is asking for.
-    if: github.event_name != 'pull_request'
+    # A red soak leg is a signal, not a release blocker.
+    continue-on-error: true
+    # Every schedule and every dispatch, PRs excluded (an 11 GB build per push
+    # is not what anyone is asking for). No dedup gate -- see above. The count
+    # guard keeps the job off runs whose targets have no ephemeral hardware,
+    # and an empty matrix is an error rather than a skip.
+    if: >-
+      github.event_name != 'pull_request' &&
+      needs.prepare-matrix.outputs.ephemeral_count != '0'
     strategy:
-      # Strix Halo is what this pool is; the other release targets have no
-      # ephemeral hardware to build for.
-      matrix:
-        gfx_target: [gfx1151]
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.ephemeral_matrix) }}
       fail-fast: false
     outputs:
-      vllm_version: ${{ steps.set-outputs.outputs.vllm_version }}
-      torch_version: ${{ steps.set-outputs.outputs.torch_version }}
-      # Non-empty only on omni builds; create-release uses it to pick the tag.
-      omni_version: ${{ steps.set-outputs.outputs.omni_version }}
-
+      vllm_version: ${{ steps.build.outputs.vllm_version }}
+      omni_version: ${{ steps.build.outputs.omni_version }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Download portable Python (python-build-standalone)
-      run: |
-        # Relocatable Python from astral-sh/python-build-standalone — no system
-        # Python/ROCm dependency. The Python version is CHANNEL-DRIVEN because the
-        # two channels' vLLM wheels target different CPython ABIs:
-        #   nightly -> cp314 (AMD's device-all-rdna nightly moved to Python 3.14)
-        #   stable  -> cp313 (AMD's per-gfx stable vLLM is still cp313)
-        # PYVER is exported so every later build step uses the right lib/ path,
-        # and qualify re-derives it from the bundle.
-        if [ "$CHANNEL" = "stable" ]; then
-          PYVER=3.13; PBS_TAG=20260602; PBS_PY=3.13.13
-        else
-          PYVER=3.14; PBS_TAG=20260623; PBS_PY=3.14.6
-        fi
-        PBS_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_TAG}/cpython-${PBS_PY}+${PBS_TAG}-x86_64-unknown-linux-gnu-install_only.tar.gz"
-        echo "channel=$CHANNEL -> Python $PBS_PY (cp${PYVER/./})"
-        echo "Downloading portable Python from $PBS_URL"
-        # Build under the runner's temp dir — no sudo, no shared-box pollution,
-        # and isolated per run (the self-hosted boxes are persistent). VLLM_ROOT
-        # is exported so every later step (and the artifact upload) uses it.
-        ROOT="$RUNNER_TEMP/vllm-build/vllm"
-        rm -rf "$RUNNER_TEMP/vllm-build"
-        mkdir -p "$RUNNER_TEMP/vllm-build"
-        # Extracts to python/ — move to vllm/ so it becomes the release root
-        curl -fsSL "$PBS_URL" | tar -xz -C "$RUNNER_TEMP/vllm-build"
-        mv "$RUNNER_TEMP/vllm-build/python" "$ROOT"
-        "$ROOT/bin/python${PYVER}" --version
-        echo "VLLM_ROOT=$ROOT" >> "$GITHUB_ENV"
-        echo "PYVER=$PYVER" >> "$GITHUB_ENV"
-        echo "Portable Python installed at $ROOT"
-
-    - name: Map GPU target to AMD wheel URLs
-      id: wheel-urls
-      run: |
-        target="${{ matrix.gfx_target }}"
-
-        # Map targets to AMD wheel URL suffixes
-        # See: https://rocm.docs.amd.com/en/latest/rocm-for-ai/vllm.html
-        case "$target" in
-          gfx110X) suffix="gfx110X-all" ;;
-          gfx1151) suffix="gfx1151" ;;
-          gfx1150) suffix="gfx1150" ;;
-          gfx120X) suffix="gfx120X-all" ;;
-          # CDNA. These suffixes are the STABLE-channel per-card aisles; the
-          # nightly channel uses AMD's device-all-cdna line instead (resolved in
-          # the install step, which is the only place the channel is known).
-          gfx942) suffix="gfx94X-dcgpu" ;;
-          gfx950) suffix="gfx950-dcgpu" ;;
-          *)
-            echo "ERROR: No AMD pre-built wheels for target: $target"
-            exit 1
-            ;;
-        esac
-
-        echo "torch_index=https://repo.amd.com/rocm/whl/${suffix}/" >> $GITHUB_OUTPUT
-        echo "vllm_index=https://rocm.frameworks.amd.com/whl/${suffix}/" >> $GITHUB_OUTPUT
-        echo "Using PyTorch index: https://repo.amd.com/rocm/whl/${suffix}/"
-        echo "Using vLLM index: https://rocm.frameworks.amd.com/whl/${suffix}/"
-
-    - name: Prepare Python environment
-      run: |
-        # No venv needed — install packages directly into the standalone Python.
-        # Pin pip to 24.3.1: it still ships --use-deprecated=legacy-resolver,
-        # which the vLLM install needs. The current resolvelib resolver
-        # RecursionErrors building its result graph on a dependency cycle in
-        # vLLM's closure (resolution.py:_has_route_to_root recurses infinitely,
-        # so no setrecursionlimit saves it); the legacy resolver avoids that path.
-        $VLLM_ROOT/bin/python3 -m pip install "pip==24.3.1"
-        echo "pip: $($VLLM_ROOT/bin/pip --version)"
-        echo "Python: $($VLLM_ROOT/bin/python3 --version)"
-
-    - name: Install vLLM + PyTorch (channel=${{ env.CHANNEL }})
-      run: |
-        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
-        TORCH_INDEX="${{ steps.wheel-urls.outputs.torch_index }}"
-        VLLM_INDEX="${{ steps.wheel-urls.outputs.vllm_index }}"
-
-        # Steer any CMake-based source build (notably onnx, pulled by amd-quark)
-        # at our bundled Python. On cp314/x86_64 some deps have no wheel yet —
-        # onnx 1.19.0 (amd-quark caps onnx<=1.19.0) only ships a cp314 *aarch64*
-        # wheel, so x86_64 falls back to the sdist. onnx's CMake find_package
-        # (Python3) / pybind11 otherwise resolve the box's system python (3.12)
-        # off PATH and emit a cpython-312 ext that pip (running 3.14) can't use.
-        # Putting the bundled interpreter FIRST on PATH makes CMake find 3.14 and
-        # build a cpython-${PYVER} ext (the -D hints alone aren't honored). No-op
-        # when a wheel is used (e.g. stable cp313).
-        export PATH="$VLLM_ROOT/bin:$PATH"
-        export CMAKE_ARGS="${CMAKE_ARGS:-} -DPython3_EXECUTABLE=$VLLM_ROOT/bin/python3 -DPython_EXECUTABLE=$VLLM_ROOT/bin/python3"
-
-        # vLLM's dependency graph trips pip's resolvelib resolver into a
-        # RecursionError (a cycle in its closure), on BOTH channels. No pip flag
-        # controls the recursion depth, so run pip via its entrypoint under a
-        # raised limit; combined with --use-deprecated=legacy-resolver below this
-        # is what lets the install complete. (pip pinned to 24.3.1 in Prepare.)
-        pip_deep() {
-          "$VLLM_ROOT/bin/python3" -c 'import sys; sys.setrecursionlimit(20000); from pip._internal.cli.main import main; sys.exit(main(sys.argv[1:]))' "$@"
-        }
-
-        if [ "$CHANNEL" = "stable" ]; then
-          # STABLE: AMD's per-card matched set — the OLDER one-build-per-gfx
-          # pattern (vLLM at rocm.frameworks.amd.com/whl/<gfx>/, torch at
-          # repo.amd.com/rocm/whl/<gfx>/), NOT the nightly single-RDNA build.
-          # ROCm 7.13 / torch 2.9.1 — a different code-object generation than the
-          # 7.14 nightly, which is the point of this validation run. Same robust
-          # install technique as nightly (legacy resolver + matched-torchvision
-          # repair), pointed at the stable sources.
-          # Pin the cp313 stable vLLM version (don't curl-discover): rocm.
-          # frameworks.amd.com WAF-403s a raw directory-listing GET from the
-          # runner's IP, but pip's PEP503 index access through --extra-index-url
-          # works. Bump this when AMD publishes a newer stable cp313 wheel at
-          # rocm.frameworks.amd.com/whl/gfx1151/vllm/ .
-          VLLM_VER="${{ github.event.inputs.stable_vllm_ver || '0.19.1.dev3+rocm7.13.0.g72ed2b398.d20260513' }}"
-          echo "stable: vLLM==$VLLM_VER"
-          # 1. Matched torch from the stable ROCm index (pulls rocm-sdk-* + triton
-          #    at the rocm7.13.0 ABI). The index carries torch 2.9.1 / 2.10.0 /
-          #    2.11.0 all at +rocm7.13.0; vLLM 0.19.1's own code guards pin it to
-          #    torch 2.9.x (>=2.9.0,<2.10.0), so use 2.9.1. NOTE: even this
-          #    code-correct version currently leaves unresolved c10::*[abi:cxx11]
-          #    symbols (tier0 T0.2) — AMD's stable vLLM wheel was built with a
-          #    different _GLIBCXX_USE_CXX11_ABI than its stable torch. That's an
-          #    upstream ABI skew the gate reports; we do not pin around it.
-          $VLLM_ROOT/bin/pip install --index-url "$TORCH_INDEX" \
-            --extra-index-url https://pypi.org/simple/ \
-            "torch==2.9.1+rocm7.13.0"
-          # 2. vLLM by version from the gfx index + PyPI for the ~70 normal deps.
-          #    Same legacy resolver as nightly (the recursion cycle is in vLLM's
-          #    graph regardless of channel); --ignore-requires-python guards any
-          #    amd-quark cp<3.13 cap.
-          ok=0
-          for attempt in 1 2 3; do
-            if pip_deep install --use-deprecated=legacy-resolver --ignore-requires-python \
-                 --extra-index-url "$VLLM_INDEX" \
-                 --extra-index-url "$TORCH_INDEX" \
-                 --extra-index-url https://pypi.org/simple/ \
-                 "vllm==$VLLM_VER"; then ok=1; break; fi
-            echo "::warning::stable vLLM install attempt $attempt failed; retry in $((attempt*10))s"
-            sleep $((attempt * 10))
-          done
-          [ "$ok" = 1 ] || { echo "::error::stable vLLM install failed after 3 attempts"; exit 1; }
-          # 3. Repair: the legacy resolver may have pulled a PyPI torchvision with
-          #    the wrong torch ABI (torchvision::nms unregistered -> import dies).
-          #    Force the matched ROCm build AFTER vLLM. pycountry is an undeclared
-          #    optional transitive (mistral_common). pip check surfaces the rest.
-          $VLLM_ROOT/bin/pip install --index-url "$TORCH_INDEX" \
-            --extra-index-url https://pypi.org/simple/ \
-            "torchvision==0.24.0+rocm7.13.0"
-          $VLLM_ROOT/bin/pip install pycountry
-          $VLLM_ROOT/bin/pip check || echo "::warning::pip check reported conflicts (see above); qualify will gate"
-        else
-          # NIGHTLY: repackage AMD's OFFICIAL nightly. AMD publishes a single
-          # universal RDNA vLLM wheel plus a date-stamped matched torch; we pair
-          # them by the shared ROCm build stamp (rocm7.14.0a<DATE>), so the set
-          # is ABI-consistent by construction — no pinning around mismatches.
-          # AMD publishes the nightly vLLM as TWO separate per-family lines,
-          # device-all-rdna and device-all-cdna, at independent versions. The
-          # line must therefore follow the matrix target, not be hardcoded.
-          # (torch does NOT: whl-multi-arch carries every arch, including
-          # rocm-sdk-device-gfx942/-gfx950, so the torch half is family-agnostic.)
-          case "${{ matrix.gfx_target }}" in
-            gfx942|gfx950) NIGHTLY_SET=device-all-cdna ;;
-            *)             NIGHTLY_SET=device-all-rdna ;;
-          esac
-          NIGHTLY_VLLM=https://rocm.frameworks-nightlies.amd.com/whl/$NIGHTLY_SET
-          NIGHTLY_TORCH=https://rocm.nightlies.amd.com/whl-multi-arch
-          echo "nightly vLLM line: $NIGHTLY_SET"
-          # torch's per-gfx kernels are an extra; map the matrix target to it.
-          case "${{ matrix.gfx_target }}" in
-            gfx1151) DEV=gfx1151 ;;
-            gfx1150) DEV=gfx1150 ;;
-            gfx110X) DEV=gfx1100 ;;
-            gfx120X) DEV=gfx1200 ;;
-            *) DEV="${{ matrix.gfx_target }}" ;;
-          esac
-          # 1. Use the version detect-nightly already resolved (so detect and
-          #    build agree even if AMD publishes a newer one mid-run); else
-          #    discover the newest cp314 wheel from the index.
-          # detect-nightly probes the RDNA line only (it gates the daily cron),
-          # so its version is valid for RDNA targets ONLY. Reusing it for a CDNA
-          # build would pin a version that does not exist on the CDNA line; leave
-          # it empty so the self-discovery below resolves from $NIGHTLY_VLLM.
-          if [ "$NIGHTLY_SET" = "device-all-rdna" ]; then
-            VLLM_VER="${{ needs.detect-nightly.outputs.vllm_ver }}"
-            ROCM_STAMP="${{ needs.detect-nightly.outputs.rocm_stamp }}"
-          else
-            VLLM_VER=""
-            ROCM_STAMP=""
-          fi
-          if [ -z "$VLLM_VER" ]; then
-            WHL=$(curl -fsSL "$NIGHTLY_VLLM/vllm/" \
-              | grep -oE 'vllm-[0-9][^"]*-cp314-cp314-linux_x86_64\.whl' \
-              | sort | tail -1)
-            VLLM_VER=$(echo "$WHL" | sed -E 's/^vllm-(.*)-cp314-cp314-linux_x86_64\.whl$/\1/' | sed 's/%2B/+/g')
-            ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
-          fi
-          [ -n "$VLLM_VER" ] || { echo "::error::no cp314 nightly vLLM version found"; exit 1; }
-          # Omni builds pin the qualified base (vLLM-Omni 0.23.0rc1 can't ride
-          # the latest nightly — see OMNI_BASE_VLLM_VER). Override the detected
-          # version so build/qualify/release all use the validated base.
-          if [ "$OMNI" = "true" ]; then
-            VLLM_VER="$OMNI_BASE_VLLM_VER"
-            ROCM_STAMP=$(echo "$VLLM_VER" | grep -oE 'rocm[0-9.]+a[0-9]+' | head -1)
-            echo "omni: pinning base to $VLLM_VER (stamp $ROCM_STAMP)"
-          fi
-          # upstream vLLM 0.21.x pins torch 2.11.0 (the wheel itself strips it);
-          # bump TORCH_VER here when vLLM bumps its torch requirement.
-          TORCH_VER=2.11.0
-          echo "nightly: vLLM==$VLLM_VER"
-          echo "nightly: torch=${TORCH_VER}+${ROCM_STAMP}[device-${DEV}]"
-          # 2. Matched torch + ROCm runtime libs + Triton + per-gfx kernels,
-          #    all resolved at the same ROCm stamp from one index.
-          $VLLM_ROOT/bin/pip install --index-url "$NIGHTLY_TORCH" \
-            --extra-index-url https://pypi.org/simple/ \
-            "torch[device-${DEV}]==${TORCH_VER}+${ROCM_STAMP}"
-          # 3a. Pre-install amd-quark. vLLM pins amd-quark>=0.8.99, but every
-          #    amd-quark >=0.7 on PyPI caps Requires-Python at <3.13 while our
-          #    nightly bundle is cp314. amd-quark is a pure-Python (py3-none-any) wheel —
-          #    the cap is a conservative untested-version guard, not a real ABI
-          #    limit — so install it ALONE with --ignore-requires-python (a tiny
-          #    candidate space). Scoping the flag here, not on the vLLM resolve,
-          #    is deliberate: passed globally it strips the Python filter from
-          #    every dep, ballooning pip's backtracking until it RecursionErrors.
-          #    Once installed and satisfying >=0.8.99, vLLM's resolve accepts it.
-          pip_deep install --ignore-requires-python "amd-quark>=0.8.99"
-          # 3b. The universal vLLM wheel + flash-attn (AMD index) + the rest from
-          #    PyPI. Install BY VERSION through the index (not a hand-built wheel
-          #    URL): the host serves the wheel only at its %2B-encoded path, so a
-          #    direct URL with a literal '+' gets WAF-403'd. Letting pip resolve
-          #    the index href fetches the correctly-encoded URL. vLLM declares no
-          #    torch dep, so the matched torch above is untouched.
-          #    Two flags, both required and complementary:
-          #    --use-deprecated=legacy-resolver: the new resolvelib resolver
-          #    RecursionErrors building its result graph on a cycle in vLLM's
-          #    dependency closure (resolution.py:_has_route_to_root recurses
-          #    without end). The legacy resolver doesn't walk that graph. (pip is
-          #    pinned to 24.3.1 above so this flag still exists.)
-          #    --ignore-requires-python: the legacy resolver re-checks
-          #    requires-python on the already-installed amd-quark (capped <3.13)
-          #    and hard-errors on cp314; the flag makes it accept it. On
-          #    the legacy (first-found, no-backtrack) resolver this can't balloon
-          #    the candidate search the way it would on the new resolver.
-          ok=0
-          for attempt in 1 2 3; do
-            if pip_deep install --use-deprecated=legacy-resolver --ignore-requires-python \
-                 --extra-index-url "$NIGHTLY_VLLM" \
-                 --extra-index-url https://pypi.org/simple/ \
-                 "vllm==$VLLM_VER"; then ok=1; break; fi
-            echo "::warning::vLLM install attempt $attempt failed; retry in $((attempt*10))s"
-            sleep $((attempt * 10))
-          done
-          [ "$ok" = 1 ] || { echo "::error::vLLM install failed after 3 attempts"; exit 1; }
-          # 3c. Repair legacy-resolver over-picks. The legacy resolver takes the
-          #    first-found version and ignores transitive UPPER bounds / ABI, so
-          #    it leaves deps that break vLLM at import (each caught by qualify
-          #    T1.5). Re-assert the correct ones here (small single-package
-          #    resolves — no cycle), then `pip check` surfaces any remaining
-          #    mis-pick in the build log without failing the build (qualify gates).
-          #
-          #    torchvision must match the ROCm torch ABI or its C++ ops
-          #    (torchvision::nms) fail to register and `import vllm` dies. Legacy
-          #    pulled a PyPI torchvision built against a different torch; force the
-          #    matched ROCm build from the nightly index, same rocm stamp. torch
-          #    2.11 pairs with torchvision 0.26 — bump TV_VER with TORCH_VER.
-          TV_VER=0.26.0
-          $VLLM_ROOT/bin/pip install --index-url "$NIGHTLY_TORCH" \
-            --extra-index-url https://pypi.org/simple/ \
-            "torchvision==${TV_VER}+${ROCM_STAMP}"
-          #    transformers needs tokenizers>=0.22.0,<=0.23.0 but legacy pulled
-          #    0.23.1, raising ImportError at import; pin it back into range.
-          $VLLM_ROOT/bin/pip install "tokenizers>=0.22.0,<=0.23.0"
-          #    pycountry: an OPTIONAL transitive nothing declares as a hard dep
-          #    (vLLM -> mistral_common -> pydantic_extra_types.language_code ->
-          #    pycountry), so no resolver installs it, yet mistral_common imports
-          #    it at module load and vllm-server dies without it. Add explicitly.
-          $VLLM_ROOT/bin/pip install pycountry
-          $VLLM_ROOT/bin/pip check || echo "::warning::pip check reported dependency conflicts (see above); qualify will gate"
-        fi
-
-        # Use the AMD pip ROCm SDK amdsmi (_rocm_sdk_core/share/amd_smi) rather
-        # than any amdsmi the wheels bundled.
-        rm -rf $SP/amdsmi $SP/amdsmi-*.dist-info
-
-        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
-          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        export LD_LIBRARY_PATH
-        # Report versions but DO NOT fail the build on a bad combination — a
-        # broken bundle must still be packaged so the qualification gate can
-        # detect and REPORT it. Fixing upstream is never our job.
-        $VLLM_ROOT/bin/python3 -c "
-        import torch; print(f'PyTorch {torch.__version__}')
-        import vllm; print(f'vLLM {vllm.__version__}')
-        " || echo "WARNING: import check failed — qualification will report this"
-
-    - name: Pre-compile Triton HIP utilities (eliminates gcc dependency)
-      run: |
-        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
-        TRITON_AMD="$SP/triton/backends/amd"
-        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
-          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        export LD_LIBRARY_PATH
-
-        # Create unversioned symlinks for ROCm libs (pip installs only have versioned .so.N)
-        ROCM_LIB="$SP/_rocm_sdk_core/lib"
-        for lib in "$ROCM_LIB"/*.so.*; do
-          name=$(basename "$lib")
-          link="$ROCM_LIB/${name%%.*}.so"
-          [ ! -e "$link" ] && ln -sf "$name" "$link"
-        done
-        ls -la "$ROCM_LIB/libamdhip64.so" || echo "WARNING: symlink not created"
-
-        # Compile the hip_utils C module with gcc directly and save into the package.
-        # We can't use Triton's compile_module_from_src because it also tries to
-        # dlopen the HIP library, which doesn't work on headless CI.
-        TRITON_AMD="$SP/triton/backends/amd"
-        PYTHON_INC="$VLLM_ROOT/include/python${PYVER}"
-
-        # Generate the C source with the HIP library path baked in
-        $VLLM_ROOT/bin/python3 -c "
-        from pathlib import Path
-        import os
-        dirname = '$TRITON_AMD'
-        src = Path(os.path.join(dirname, 'driver.c')).read_text()
-        # Bake in the relative path that will resolve at runtime via LD_LIBRARY_PATH
-        src = src.replace('/*py_libhip_search_path*/', 'libamdhip64.so', 1)
-        Path('/tmp/hip_utils.c').write_text(src)
-        print('Generated /tmp/hip_utils.c')
-        "
-
-        # Compile with gcc
-        gcc /tmp/hip_utils.c -O3 -shared -fPIC -Wno-psabi \
-          -o "$TRITON_AMD/hip_utils_prebuilt.so" \
-          -I"$TRITON_AMD/include" \
-          -I"$PYTHON_INC"
-        echo "Pre-compiled: $TRITON_AMD/hip_utils_prebuilt.so ($(stat -c%s "$TRITON_AMD/hip_utils_prebuilt.so") bytes)"
-
-        # Patch Triton to load the pre-built .so instead of JIT-compiling
-        DRIVER_PY="$TRITON_AMD/driver.py"
-        sed -i 's|mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|_pso = os.path.join(dirname, "hip_utils_prebuilt.so")\n        if os.path.exists(_pso):\n            import importlib.util as _ilu\n            _sp = _ilu.spec_from_file_location("hip_utils", _pso)\n            mod = _ilu.module_from_spec(_sp)\n            _sp.loader.exec_module(mod)\n        else:\n            mod = compile_module_from_src(src=src, name="hip_utils", include_dirs=include_dirs)|' "$DRIVER_PY"
-        $VLLM_ROOT/bin/python3 -c "import ast; ast.parse(open('$DRIVER_PY').read()); print('Patched driver.py — syntax OK')"
-
-    - name: Create launcher script
-      run: |
-        cat > $VLLM_ROOT/bin/vllm-server << 'LAUNCHER_EOF'
-        #!/bin/bash
-        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-        VENV_DIR="$(dirname "$SCRIPT_DIR")"
-        # Glob the bundled python3.* dir so the launcher is Python-version-agnostic
-        # (the bundle is cp313 or cp314 depending on channel).
-        SP="$(echo "$VENV_DIR"/lib/python3.*/site-packages)"
-        # Add all bundled ROCm library paths
-        for libdir in "$SP"/_rocm_sdk_*/lib "$SP"/torch/lib; do
-        [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        # Also add LLVM lib for the bundled clang
-        LD_LIBRARY_PATH="$SP/_rocm_sdk_core/lib/llvm/lib:${LD_LIBRARY_PATH}"
-        export LD_LIBRARY_PATH
-        export PYTHONPATH="$SP/_rocm_sdk_core/share/amd_smi:${PYTHONPATH:-}"
-        export FLASH_ATTENTION_TRITON_AMD_ENABLE=TRUE
-        # Use bundled clang for Triton JIT (no system gcc needed)
-        CLANG="$SP/_rocm_sdk_core/lib/llvm/bin/clang"
-        [ -f "$CLANG" ] && chmod +x "$CLANG" "$CLANG"-* 2>/dev/null
-        export CC="$CLANG"
-        exec "$SCRIPT_DIR/python3" -m vllm.entrypoints.openai.api_server "$@"
-        LAUNCHER_EOF
-
-        # Remove YAML indentation from heredoc
-        sed -i 's/^        //' $VLLM_ROOT/bin/vllm-server
-        chmod +x $VLLM_ROOT/bin/vllm-server
-        echo "Launcher script:"
-        cat $VLLM_ROOT/bin/vllm-server
-
-    - name: Strip unnecessary files to reduce size
-      run: |
-        cd $VLLM_ROOT
-        echo "=== Size before cleanup ==="
-        du -sh .
-
-        SP="lib/python${PYVER}/site-packages"
-
-        # Remove pip/wheel (keep setuptools — torch.utils.cpp_extension needs it)
-        rm -rf $SP/pip* $SP/wheel* 2>/dev/null || true
-
-        # Remove __pycache__ and .pyc
-        find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-        find . -name "*.pyc" -delete 2>/dev/null || true
-
-        # Remove test/benchmark dirs (but NOT torch.testing — it's imported at runtime)
-        rm -rf $SP/torch/test $SP/torch/benchmarks 2>/dev/null || true
-
-        # Remove packages not needed for inference serving (~500MB)
-        rm -rf $SP/pyarrow* $SP/opencv* $SP/cv2* 2>/dev/null || true
-        rm -rf $SP/onnx* $SP/pandas* $SP/plotly* 2>/dev/null || true
-        rm -rf $SP/datasets* $SP/evaluate* $SP/peft* $SP/timm* 2>/dev/null || true
-        rm -rf $SP/boto3* $SP/botocore* $SP/s3transfer* 2>/dev/null || true
-        rm -rf $SP/azure* $SP/google_cloud* $SP/google_auth* $SP/msal* 2>/dev/null || true
-        rm -rf $SP/tensorizer* $SP/runai* 2>/dev/null || true
-        rm -rf $SP/aiter_meta* 2>/dev/null || true
-
-        # Trim LLVM toolchain: keep only clang + its libs (~350MB saved)
-        LLVM="$SP/_rocm_sdk_core/lib/llvm"
-        # Keep the clang driver and its versioned binary (clang-NN). The LLVM
-        # major tracks the ROCm release (clang-22 on 7.13, clang-23 on 7.14);
-        # hardcoding clang-22 would delete the real compiler on newer ROCm and
-        # break Triton's runtime JIT. Match clang-* so it survives any version.
-        find "$LLVM/bin" -type f ! -name "clang" ! -name "clang-*" -delete 2>/dev/null || true
-        find "$LLVM/bin" -type l ! -name "clang" -delete 2>/dev/null || true
-        # Keep only libs that clang needs (libclang-cpp, libLLVM, rocm_sysdeps)
-        find "$LLVM/lib" -name "*.so*" \
-          ! -name "libclang-cpp*" \
-          ! -name "libLLVM*" \
-          -delete 2>/dev/null || true
-        rm -rf "$LLVM/lib/clang/"*/include/cuda_wrappers 2>/dev/null || true
-
-        # Trim ROCm SDK bin/ (Python wrapper scripts, not needed)
-        rm -rf "$SP/_rocm_sdk_core/bin" 2>/dev/null || true
-
-        # Remove Python stdlib we don't need
-        rm -rf lib/python${PYVER}/test lib/python${PYVER}/tkinter lib/python${PYVER}/idlelib 2>/dev/null || true
-        rm -rf lib/python${PYVER}/turtledemo lib/python${PYVER}/ensurepip 2>/dev/null || true
-        # Keep include/ — Triton JIT needs Python.h headers
-
-        # Ensure bundled clang is executable (permissions lost during tar)
-        chmod +x "$LLVM/bin/clang"* 2>/dev/null || true
-
-        # NOTE: Do NOT strip .so files — AMD ROCm wheels use special ELF
-        # alignment that strip corrupts, and numpy/scipy also break.
-
-        echo "=== Size after cleanup ==="
-        du -sh .
-        echo ""
-        echo "Top consumers:"
-        du -sh $SP/torch/ $SP/vllm/ $SP/_rocm_sdk_core/ $SP/aiter/ $SP/triton/ 2>/dev/null || true
-
-    - name: Layer vLLM-Omni onto the bundle (omni builds only)
-      # MUST run AFTER the Strip step: Strip deletes opencv/onnx/peft/timm (and
-      # pip) — exactly the deps the omni layer reinstalls. build_omni_layer.sh
-      # re-bootstraps pip and pulls vllm-omni + its runtime/multimodal deps + an
-      # ABI-matched torchaudio. torchaudio must come from the SAME ROCm index as
-      # the bundled torch: per-gfx stable index on the stable channel, AMD's
-      # multi-arch nightly index on nightly.
-      if: ${{ env.OMNI == 'true' }}
-      env:
-        TORCH_INDEX: ${{ env.CHANNEL == 'stable' && steps.wheel-urls.outputs.torch_index || 'https://rocm.nightlies.amd.com/whl-multi-arch' }}
-      run: |
-        bash scripts/build_omni_layer.sh
-
-    - name: Verify bundled environment works
-      run: |
-        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
-        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
-          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        export LD_LIBRARY_PATH
-
-        $VLLM_ROOT/bin/python3 -c "import vllm; print(f'vLLM {vllm.__version__} OK')"
-        $VLLM_ROOT/bin/python3 -c "import torch; print(f'PyTorch {torch.__version__} OK')"
-        $VLLM_ROOT/bin/python3 -c "
-        # Verify native extensions exist (they load only with GPU present)
-        import os, pathlib
-        sp = pathlib.Path('$SP/vllm')
-        for ext in ['_C.abi3.so', '_rocm_C.abi3.so']:
-            p = sp / ext
-            assert p.exists(), f'Missing {ext}'
-            print(f'{ext}: {p.stat().st_size // 1048576} MB')
-        print('Native extensions verified')
-        "
-        bash -n $VLLM_ROOT/bin/vllm-server
-        echo "All sanity checks passed"
-
-    - name: Report final size
-      run: |
-        echo "=== Final artifact ==="
-        du -sh $VLLM_ROOT/
-        echo ""
-        du -sh $VLLM_ROOT/*/ 2>/dev/null
-
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+    - name: Build the bundle
+      id: build
+      uses: ./.github/actions/build-vllm-bundle
       with:
-        name: ephemeral-vllm-ubuntu-rocm-${{ matrix.gfx_target }}-x64
-        path: ${{ env.VLLM_ROOT }}/
-        # CRITICAL: the AMD ROCm wheels ship the per-gfx GPU code objects in
-        # HIDDEN dot-dirs (torch/.kpack/torch_gfx1151.kpack,
-        # _rocm_sdk_libraries/.kpack/{blas,fft,rand,rccl}_lib_gfx1151.kpack,
-        # .devel_links/). Since v4, upload-artifact EXCLUDES hidden files by
-        # default — dropping these silently produces a bundle that loads and
-        # enumerates the GPU but dies on the first kernel launch with
-        # hipErrorInvalidImage. include-hidden-files keeps them. Do not remove.
-        include-hidden-files: true
-        retention-days: 7
-        compression-level: 6
-
-    - name: Set job outputs
-      id: set-outputs
-      run: |
-        SP="$VLLM_ROOT/lib/python${PYVER}/site-packages"
-        for libdir in $SP/_rocm_sdk_*/lib $SP/torch/lib; do
-          [ -d "$libdir" ] && LD_LIBRARY_PATH="${libdir}:${LD_LIBRARY_PATH:-}"
-        done
-        export LD_LIBRARY_PATH
-
-        vllm_ver=$($VLLM_ROOT/bin/python3 -c "import vllm; print(vllm.__version__)")
-        torch_ver=$($VLLM_ROOT/bin/python3 -c "import torch; print(torch.__version__)")
-        echo "vllm_version=$vllm_ver" >> $GITHUB_OUTPUT
-        echo "torch_version=$torch_ver" >> $GITHUB_OUTPUT
-        # Empty on non-omni builds. Read from dist-info (no heavy import) so the
-        # create-release tag can distinguish vllm-omni* artifacts.
-        omni_ver=$(ls -d "$SP"/vllm_omni-*.dist-info 2>/dev/null | head -1 \
-          | sed -E 's#.*/vllm_omni-(.*)\.dist-info#\1#')
-        echo "omni_version=$omni_ver" >> $GITHUB_OUTPUT
-
-    - name: Clean up
-      if: always()
-      run: |
-        # No sudo — it's under the runner's temp dir. Free the box for the next run.
-        rm -rf "$RUNNER_TEMP/vllm-build" || true
-
+        gfx_target: ${{ matrix.gfx_target }}
+        # Prefixed so it falls outside every name the release jobs resolve.
+        artifact_name: ephemeral-vllm-ubuntu-rocm-${{ matrix.gfx_target }}-x64
+        retention_days: '7'
+        channel: ${{ env.CHANNEL }}
+        omni: ${{ env.OMNI }}
+        omni_base_vllm_ver: ${{ env.OMNI_BASE_VLLM_VER }}
+        vllm_ver: ${{ needs.detect-nightly.outputs.vllm_ver }}
+        rocm_stamp: ${{ needs.detect-nightly.outputs.rocm_stamp }}
+        stable_vllm_ver: ${{ github.event.inputs.stable_vllm_ver }}
 
   qualify-ephemeral:
-    needs: build-ubuntu-ephemeral
     runs-on: [self-hosted, Linux, strix-halo, ephemeral]
+    needs: [prepare-matrix, build-ubuntu-ephemeral]
     continue-on-error: true
-    env:
-      GFX: gfx1151
-    # Matches build-ubuntu-ephemeral rather than the release path's gate.
-    # The persistent qualify additionally requires create_release or omni on
-    # a dispatch; that guards a release, and this job cannot make one.
-    if: github.event_name != 'pull_request'
+    # continue-on-error on the build leg reports success to `needs` even when
+    # it failed, so this can start after a failed build and stop at the
+    # download. That costs one short VM and keeps the run green, which is the
+    # right trade for a soak.
+    if: >-
+      github.event_name != 'pull_request' &&
+      needs.prepare-matrix.outputs.ephemeral_count != '0'
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.ephemeral_matrix) }}
+      fail-fast: false
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Download gfx1151 artifact
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        set -euo pipefail
-        WORK="${{ runner.temp }}/vllm-qual"
-        DEST="$WORK/vllm"
-        ZIP="$WORK/artifact.zip"
-        mkdir -p "$DEST"
-        echo "=== Disk before download ==="; df -h "$WORK" || true
-
-        # The build artifact is ~3.3 GB (extracts to ~11 GB). actions/download-artifact@v4
-        # is unreliable for artifacts this size on self-hosted runners, so pull the
-        # artifact zip directly with curl (streams to disk, resumable) and unzip it.
-        # Resolve the artifact id via the REST API with curl + python3 — the box
-        # does not have the gh CLI installed.
-        ART_ID=$(curl -fsSL \
-                   -H "Authorization: Bearer $GH_TOKEN" \
-                   -H "Accept: application/vnd.github+json" \
-                   "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-                 | python3 -c "import sys,json; print(next((a['id'] for a in json.load(sys.stdin)['artifacts'] if a['name']=='ephemeral-vllm-ubuntu-rocm-gfx1151-x64'), ''))")
-        [ -n "$ART_ID" ] || { echo "::error::gfx1151 artifact not found for this run"; exit 1; }
-        echo "Artifact id: $ART_ID"
-
-        avail_gb=$(df -BG --output=avail "$WORK" | tail -1 | tr -dc '0-9')
-        echo "Available space: ${avail_gb} GB"
-        if [ "${avail_gb:-0}" -lt 15 ]; then
-          echo "::error::Only ${avail_gb} GB free on the runner; need ~15 GB for the 11 GB build."
-          exit 1
-        fi
-
-        ok=0
-        for attempt in 1 2 3; do
-          echo "=== curl attempt $attempt ==="
-          if curl -fL --retry 5 --retry-delay 10 --retry-all-errors -C - \
-                  -H "Authorization: Bearer $GH_TOKEN" \
-                  -H "Accept: application/vnd.github+json" \
-                  -o "$ZIP" \
-                  "https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${ART_ID}/zip"; then
-            ok=1; break
-          fi
-          echo "attempt $attempt failed; retrying in 15s"; sleep 15
-        done
-        [ "$ok" = "1" ] || { echo "::error::artifact zip download failed after 3 attempts"; df -h "$WORK" || true; exit 1; }
-        echo "Downloaded zip: $(du -h "$ZIP" | cut -f1)"
-
-        echo "=== Extracting ==="
-        if command -v unzip >/dev/null 2>&1; then
-          unzip -q -o "$ZIP" -d "$DEST"
-        else
-          python3 -m zipfile -e "$ZIP" "$DEST"
-        fi
-        rm -f "$ZIP"   # reclaim space immediately
-        echo "Extracted $(du -sh "$DEST" | cut -f1) to $DEST"
-        echo "=== Disk after extract ==="; df -h "$WORK" || true
-
-    - name: Restore permissions and ROCm symlinks
-      run: |
-        # upload-artifact drops the +x bit and the unversioned .so symlinks the
-        # build created, so rebuild both before running the harness.
-        ROOT="${{ runner.temp }}/vllm-qual/vllm"
-        # The bundle's Python version is channel-dependent (cp313 stable / cp314
-        # nightly); glob it rather than hardcode.
-        SP="$(echo "$ROOT"/lib/python3.*/site-packages)"
-        chmod +x "$ROOT/bin/"* 2>/dev/null || true
-        chmod +x "$SP/_rocm_sdk_core/lib/llvm/bin/"clang* 2>/dev/null || true
-        ROCM_LIB="$SP/_rocm_sdk_core/lib"
-        for lib in "$ROCM_LIB"/*.so.*; do
-          [ -e "$lib" ] || continue
-          name=$(basename "$lib"); link="$ROCM_LIB/${name%%.*}.so"
-          # Use `if` (not `&&`) so a pre-existing symlink doesn't leave the loop
-          # with exit 1 and trip `set -e`. The artifact preserves these symlinks,
-          # so this is now mostly a defensive no-op.
-          if [ ! -e "$link" ]; then ln -sf "$name" "$link"; fi
-        done
-
-    - name: Run 16-test qualification (tier0 + tier1 + tier2)
-      id: qual
-      run: |
-        WORK="${{ runner.temp }}/vllm-qual"
-        ROOT="$WORK/vllm"
-        PY="$ROOT/bin/python3"
-        FRAG="$WORK/fragments"; mkdir -p "$FRAG"
-        Q="$GITHUB_WORKSPACE/scripts/qualify"
-        TAG="vllm${{ needs.build-ubuntu-ephemeral.outputs.vllm_version }}-${GFX}"
-        # Omni builds qualify the omni serving path and record an omni candidate tag.
-        if [ "$OMNI" = "true" ]; then
-          TAG="vllm-omni${{ needs.build-ubuntu-ephemeral.outputs.omni_version }}-${GFX}"
-        fi
-
-        # The tiers are run WITHOUT --fail-on-error so all 16 tests execute and
-        # emit a JSON fragment even when one fails; `aggregate --fail-on-no-promote`
-        # is the single gate that decides pass/fail for the whole job.
-        echo "::group::Tier 0 — static bundle verification (T0.1–T0.6)"
-        "$PY" "$Q/tier0_static.py"   --bundle-root "$ROOT" --gfx-target "$GFX" \
-            --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier0-report.json" || true
-        echo "::endgroup::"
-
-        echo "::group::Tier 1 — hardware smoke (T1.1–T1.5)"
-        "$PY" "$Q/tier1_smoke.py"    --bundle-root "$ROOT" --gfx-target "$GFX" \
-            --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier1-report.json" || true
-        echo "::endgroup::"
-
-        # Tier 2 functional inference. Omni bundles run the omni serving path
-        # (vllm-omni-server + single-GPU deploy config) instead of plain vLLM;
-        # both emit a `tier2` fragment so the aggregate require-tiers rule is
-        # identical. The two are mutually exclusive per run.
-        if [ "$OMNI" = "true" ]; then
-          echo "::group::Tier 2 (omni) — functional inference via vllm-omni-server"
-          "$PY" "$Q/tier2_omni.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
-              --channel "$CHANNEL" --candidate-tag "$TAG" --logs-dir "$FRAG" \
-              --output "$FRAG/tier2-report.json" || true
-          echo "::endgroup::"
-        else
-          echo "::group::Tier 2 — functional inference (T2.1–T2.5)"
-          "$PY" "$Q/tier2_inference.py" --bundle-root "$ROOT" --gfx-target "$GFX" \
-              --channel "$CHANNEL" --candidate-tag "$TAG" \
-              --model Qwen/Qwen2.5-0.5B-Instruct --logs-dir "$FRAG" \
-              --output "$FRAG/tier2-report.json" || true
-          echo "::endgroup::"
-        fi
-
-        echo "=== Aggregate fragments → qualification report (gates the job) ==="
-        "$PY" "$Q/aggregate.py" --fragments-dir "$FRAG" --gfx-target "$GFX" \
-            --channel "$CHANNEL" --candidate-tag "$TAG" \
-            --require-tiers tier0,tier1,tier2 --hardware-validated \
-            --output "$FRAG/qualification-report.json" \
-            --fail-on-no-promote
-
-    - name: Upload qualification report and fragments
-      if: always()
-      uses: actions/upload-artifact@v4
+    - name: Qualify the bundle
+      id: qualify
+      uses: ./.github/actions/qualify-vllm-bundle
       with:
-        name: ephemeral-qualification-gfx1151
-        path: |
-          ${{ runner.temp }}/vllm-qual/fragments/*.json
-          ${{ runner.temp }}/vllm-qual/fragments/*.log
-        if-no-files-found: warn
-
-    - name: Tear down and clean up
-      if: always()
-      run: |
-        # Redundant on an ephemeral runner -- the VM is destroyed after the
-        # job -- but kept so the two job bodies stay comparable.
-        WORK="${{ runner.temp }}/vllm-qual"
-        pkill -9 -f "vllm.entrypoints.openai.api_server" 2>/dev/null || true
-        rm -rf "$WORK" || true
-
+        gfx: ${{ matrix.gfx_target }}
+        build_artifact: ephemeral-vllm-ubuntu-rocm-${{ matrix.gfx_target }}-x64
+        # Outside publish-qualification's `qualification-*` glob on purpose:
+        # soak results must not reach the published feed.
+        report_artifact_name: ephemeral-qualification-${{ matrix.gfx_target }}
+        channel: ${{ env.CHANNEL }}
+        omni: ${{ env.OMNI }}
+        vllm_version: ${{ needs.build-ubuntu-ephemeral.outputs.vllm_version }}
+        omni_version: ${{ needs.build-ubuntu-ephemeral.outputs.omni_version }}
 
   # Publish the qualification result (pass OR fail) to the qualification-data
   # branch so the external dashboard can poll it. Runs on a hosted runner (the


### PR DESCRIPTION
Runs the existing build and qualification on the AMD DevLab **ephemeral** pool, alongside the `dev_lab` jobs rather than in place of them.

The ephemeral pool provisions a Strix Halo (gfx1151) VM per job from a golden image and destroys it after, so each run starts from a known state and nothing is left behind on shared hardware.

**This branch no longer copies the two jobs.** Per review, `build-ubuntu` and `qualify` are now composite actions that both pools call. The previous version of this branch duplicated them, and the duplicates were stale before they landed.

## What is added

| | |
|---|---|
| `.github/actions/build-vllm-bundle` | the build steps, verbatim, with inputs |
| `.github/actions/qualify-vllm-bundle` | the qualification steps, verbatim, with inputs |
| `build-ubuntu-ephemeral` | calls the build action on `[self-hosted, Linux, strix-halo, ephemeral]` |
| `qualify-ephemeral` | calls the qualify action, `needs: build-ubuntu-ephemeral` |

`build-ubuntu` and `qualify` become thin callers of the same two actions. The workflow drops ~830 lines of inline body; the soak chain costs 37 lines.

Both soak jobs are `continue-on-error: true`.

## Why composite actions rather than a matrix axis on `runs-on`

The two pools are addressed differently, and cannot share one `runs-on`:

- **`dev_lab`** is a runner **group**, selected with `group:` so a leg cannot land on a Linux box in another group the repo can also see (Default is `visibility:all`) — that was #22.
- **`ephemeral`** is a **label** pool. The orchestrator registers its runners to the *repo*, and a repo-registered runner is always in the repo's Default group, so `group:` can never select it. It is reached by its specific labels instead.

Driving both from one matrix means a computed `runs-on`. Beyond mixing two shapes through `fromJSON`, a computed `runs-on` is opaque to static analysis — including the orchestrator's own reachability check, which reports which watched repos can address the pool and explicitly declines to guess at an expression. Today it can read this workflow and answer; after that change it could not.

Composite actions keep `runs-on` literal in both jobs, and keep the per-job keys the soak legs need:

- their own `if:`, so the soak has **no dedup gate** while the release path keeps its own, unchanged;
- `continue-on-error`, which is **not supported** on a job that calls a reusable workflow — which is why this is a composite action and not `workflow_call`.

## Two deliberate differences beyond runs-on

**gfx1151 only.** That is the silicon this pool has. It now comes from the same registry that drives the dev_lab legs rather than a hardcoded matrix:

```
QUALIFICATION_POOLS='{"gfx1151":["dev_lab","ephemeral"]}'
```

`prepare-matrix` emits one leg per (target, pool). Adding hardware stays a one-line change, and a target can never be soaked on hardware it is not qualified on.

**No dedup gate.** The release path skips the build when `detect-nightly` says the wheel has already been qualified. Right for a shared box, wrong for a pool being soaked — it would idle these jobs on every day AMD does not publish, which is most days. The soak chain runs on every schedule and every dispatch, and still skips PRs (an 11 GB build per push is not what anyone is asking for).

## Isolation from the release path

Verified job by job against `main` — every pre-existing job's `runs-on`, `needs`, `if:`, `strategy`, `outputs` and artifact names are unchanged. `prepare-matrix` emits the same `qualify_matrix` and `qualify_targets` byte for byte; it only gains two outputs.

- the soak jobs `needs:` each other and not `build-ubuntu`
- `publish-qualification` still `needs: qualify`; `create-release` still `needs: [prepare-matrix, build-ubuntu, qualify]`
- soak artifacts are **prefixed** `ephemeral-`, so they fall outside both the exact names `create-release` resolves *and* `publish-qualification`'s `qualification-*` glob. (A suffix would have been caught by that glob and published soak results into the feed.)
- `continue-on-error` plus no downstream `needs` means a red soak leg cannot fail the workflow or block a release

Ephemeral bundles keep 7 days rather than 30 — an 11 GB bundle rebuilt daily is not worth a month of storage when nothing downstream reads it.

## How the extraction was checked

The step bodies were moved mechanically, then diffed back against `main` with the substitutions reversed: both are byte-identical, 661 lines for build and 155 for qualify. `actionlint` is clean across the repo (it resolves the local actions and validates every `with:` against their declared inputs). `.github/actionlint.yaml` declares the two self-hosted labels so a real typo is still an error.

## The trade

This chain builds its own bundle, so the comparison is whole-path against whole-path rather than two runners over one artifact. That is the price of exercising the build on this pool at all, and the build is the half that would otherwise never run here.

One wrinkle worth naming: `continue-on-error` on the build leg reports success to `needs`, so `qualify-ephemeral` can start after a failed soak build and stop at the download. That costs one short VM and keeps the run green.

## Decommissioning

When the `dev_lab` box goes away: delete `build-ubuntu` and `qualify`, drop the `-ephemeral` suffixes, restore the dedup gate and the full matrix, and repoint `publish-qualification` and `create-release`. To call the trial off instead: delete the two soak jobs and the `"ephemeral"` entry in `QUALIFICATION_POOLS`. Nothing else refers to them.
