### PR TITLE
Publish gating test T0.5 in the qualification feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Our GitHub Actions workflow:
 - Installs **PyTorch ROCm** from AMD's pip index (`https://repo.amd.com/rocm/whl/<target>/`)
 - Installs **vLLM ROCm** (pre-built wheel) from AMD's vLLM wheel index (`https://wheels.vllm.ai/rocm/`), which pulls the matching `rocm-sdk-core` and `rocm-sdk-libraries-gfx<target>` wheels as transitive deps
 - Generates a `bin/vllm-server` shim that wires up `LD_LIBRARY_PATH` / `PYTHONPATH` at startup
-- Runs a **15-test qualification** on the **gfx1151** build on self-hosted AMD GPU hardware (Strix Halo) — Tier 0 static bundle checks, Tier 1 hardware smoke, Tier 2 functional inference — aggregates the results into a qualification report, and gates all releases on the build being promotable (see [`scripts/qualify`](scripts/qualify/README.md))
+- Runs a **16-test qualification** on the **gfx1151** build on self-hosted AMD GPU hardware (Strix Halo) — Tier 0 static bundle checks, Tier 1 hardware smoke, Tier 2 functional inference — aggregates the results into a qualification report, and gates all releases on the build being promotable (see [`scripts/qualify`](scripts/qualify/README.md))
 - Tars the result, splits it into `< 2 GB` parts, and publishes the release
 
 | GPU Target | Ubuntu |

--- a/docs/dashboard-plan.md
+++ b/docs/dashboard-plan.md
@@ -6,7 +6,7 @@ consumes is [`qualification-feed.md`](qualification-feed.md).
 
 ## What it answers
 
-For each build: **how many of the 15 tests passed/failed, and did the build qualify to
+For each build: **how many of the 16 tests passed/failed, and did the build qualify to
 release?** — plus the trend of that over time, and which tests fail most often.
 
 ## Data source
@@ -24,12 +24,12 @@ dashboard is a pure consumer — it never writes back.
 
 | View | Type | Reads (from `index.json`) |
 |------|------|----------------------------|
-| **Fleet status tiles** (per target) | status card: qualified ✓/✗, `7/15`, version | `latest/<target>.json` (or newest entry per `gfx_target`) |
+| **Fleet status tiles** (per target) | status card: qualified ✓/✗, `8/16`, version | `latest/<target>.json` (or newest entry per `gfx_target`) |
 | **Qualification rate over time** | line / % | `qualified` + `generated_at` bucketed by day/week |
 | **Pass/fail per build** | stacked bar, time x-axis | `tests.{passed,failed,warned,skipped}` |
 | **Trend annotated with versions** | line + markers | above + `vllm_version` / `torch_version` change points |
 | **Failure Pareto** (which tests fail most) | horizontal bar | `results` aggregated across builds → fail-count per test id |
-| **Tier heatmap** (builds × 15 tests) | grid | `results` per build |
+| **Tier heatmap** (builds × 16 tests) | grid | `results` per build |
 | **Build drill-down** | detail panel | `report_url` → full report (`tiers[].tests[].error/details`) |
 
 The first four need only the compact counts; the failure-analysis views need the
@@ -43,10 +43,10 @@ report).
 │  vLLM-ROCm Build Qualification                          gfx1151 ▾  │
 ├───────────────┬───────────────┬───────────────┬──────────────────┤
 │ gfx1151  ✗    │ gfx1150  —    │ gfx120X  —    │ gfx110X  —       │  tiles: latest/
-│ 7/15  not qual│ no hw test    │ no hw test    │ no hw test       │
+│ 8/16  not qual│ no hw test    │ no hw test    │ no hw test       │
 ├───────────────┴───────────────┴───────────────┴──────────────────┤
 │  Qualification rate (30d)            │  Pass/fail per build       │
-│  100% ┤      ╭─╮                     │  15 ┤ █▆ █ ▆█ ▆▆█ ▂        │  index.builds[]
+│  100% ┤      ╭─╮                     │  16 ┤ █▆ █ ▆█ ▆▆█ ▂        │  index.builds[]
 │   50% ┤ ╭──╮ │ ╰──╴                  │     ┤ ▂▂ ▂ ▂▂ ▂▂▂ █        │
 │    0% ┼─╯  ╰─╯                       │     └────────────────────  │
 ├──────────────────────────────────────────────────────────────────┤
@@ -73,7 +73,7 @@ report).
   "passing". Don't imply green where there's no data.
 - A **single build is one point** — trend views need history to accumulate on the
   branch before they're meaningful.
-- `total` is always 15 and **`missing` counts as failed**, so a crashed tier reads as
+- `total` is always 16 and **`missing` counts as failed**, so a crashed tier reads as
   red, never as a smaller-but-green total.
 
 ## Not in scope here

--- a/docs/qualification-feed.md
+++ b/docs/qualification-feed.md
@@ -97,9 +97,7 @@ field so re-runs are visible, but they don't fork the record — the dashboard a
   `"missing"` in `results` and **counted as `failed`**. So `passed + failed +
   warned + skipped == 16` always, and the counts never look misleadingly small.
 - **`results`** values are one of `pass | fail | warn | skip | missing`. Test ids are
-  the canonical 16: T0.1–T0.6, T1.1–T1.5, T2.1–T2.5. T0.5 (gfx code-object packs
-  present) is a gating tier-0 check, so it appears in `results` and a red T0.5 shows
-  as a failed cell rather than hiding behind an all-green tier-0 row. This lets the dashboard
+  the canonical 16: T0.1–T0.6, T1.1–T1.5, T2.1–T2.5. This lets the dashboard
   compute failure-frequency and heatmap views from `index.json` alone (no N+1 fetch).
 - **`qualified`** is the release gate (`true` only if every required tier passed).
 - **`report_url`** is relative to the feed base — open it for the full per-test

--- a/docs/qualification-feed.md
+++ b/docs/qualification-feed.md
@@ -69,12 +69,12 @@ field so re-runs are visible, but they don't fork the record — the dashboard a
       "vllm_version": "0.22.1+rocm722",
       "torch_version": "2.11.0+rocm7.13.0",
       "rocm_version": "7.13.0",
-      "tests": { "passed": 7, "failed": 8, "warned": 0, "skipped": 0, "total": 15 },
+      "tests": { "passed": 8, "failed": 8, "warned": 0, "skipped": 0, "total": 16 },
       "qualified": false,                      // == promoted; "did it qualify to release"
       "overall": "fail",                       // pass | fail | warn
       "blocked_by": ["tier0=fail", "tier1=fail", "tier2 missing"],
-      "results": {                             // per-test status across the 15-test suite
-        "T0.1": "fail", "T0.2": "fail", "T0.3": "pass", "T0.4": "pass", "T0.6": "pass",
+      "results": {                             // per-test status across the 16-test suite
+        "T0.1": "fail", "T0.2": "fail", "T0.3": "pass", "T0.4": "pass", "T0.5": "pass", "T0.6": "pass",
         "T1.1": "fail", "T1.2": "pass", "T1.3": "pass", "T1.4": "pass", "T1.5": "pass",
         "T2.1": "missing", "T2.2": "missing", "T2.3": "missing", "T2.4": "missing", "T2.5": "missing"
       },
@@ -92,12 +92,14 @@ field so re-runs are visible, but they don't fork the record — the dashboard a
 
 ### Field notes
 
-- **`tests.total` is always 15** (the canonical suite). A tier that produced no
+- **`tests.total` is always 16** (the canonical suite). A tier that produced no
   fragment (e.g. Tier 2 when the server failed to boot) has its tests marked
   `"missing"` in `results` and **counted as `failed`**. So `passed + failed +
-  warned + skipped == 15` always, and the counts never look misleadingly small.
+  warned + skipped == 16` always, and the counts never look misleadingly small.
 - **`results`** values are one of `pass | fail | warn | skip | missing`. Test ids are
-  the canonical 15: T0.1–T0.4, T0.6, T1.1–T1.5, T2.1–T2.5. This lets the dashboard
+  the canonical 16: T0.1–T0.6, T1.1–T1.5, T2.1–T2.5. T0.5 (gfx code-object packs
+  present) is a gating tier-0 check, so it appears in `results` and a red T0.5 shows
+  as a failed cell rather than hiding behind an all-green tier-0 row. This lets the dashboard
   compute failure-frequency and heatmap views from `index.json` alone (no N+1 fetch).
 - **`qualified`** is the release gate (`true` only if every required tier passed).
 - **`report_url`** is relative to the feed base — open it for the full per-test

--- a/scripts/publish_qualification.py
+++ b/scripts/publish_qualification.py
@@ -11,7 +11,7 @@ and writes, under --data-dir (the `qualification/` dir on the data branch):
 
 The index entry is keyed by build_id, so re-running this for the same build is
 an idempotent upsert (no duplicate rows/files). Counts are normalized to the
-canonical 15-test suite: a tier that produced no fragment (e.g. Tier 2 when the
+canonical 16-test suite: a tier that produced no fragment (e.g. Tier 2 when the
 server failed to boot) has its tests marked "missing" and folded into `failed`,
 so the dashboard never shows a misleadingly small total.
 
@@ -23,13 +23,13 @@ from pathlib import Path
 
 SCHEMA_VERSION = 1
 
-# The canonical 15-test suite. Tier 0 intentionally skips T0.5.
+# The canonical 16-test suite, mirroring exactly what the tier runners execute.
 TIER_TESTS = {
-    "tier0": ["T0.1", "T0.2", "T0.3", "T0.4", "T0.6"],
+    "tier0": ["T0.1", "T0.2", "T0.3", "T0.4", "T0.5", "T0.6"],
     "tier1": ["T1.1", "T1.2", "T1.3", "T1.4", "T1.5"],
     "tier2": ["T2.1", "T2.2", "T2.3", "T2.4", "T2.5"],
 }
-TOTAL_TESTS = sum(len(v) for v in TIER_TESTS.values())  # 15
+TOTAL_TESTS = sum(len(v) for v in TIER_TESTS.values())  # 16
 
 
 def _int(v):


### PR DESCRIPTION
### What's wrong

T0.5 (`gfx code-object packs present`) is a **gating** Tier 0 check. If it fails, the build fails and release is blocked. But the dashboard feed never showed it. `publish_qualification.py` builds the feed's per-test `results` map from a hardcoded `TIER_TESTS` list, and that list left T0.5 out (it enumerated only T0.1–T0.4, T0.6 for tier0).

So the feed and the gate disagreed:
- A build could fail **only** on T0.5 and show every Tier 0 cell green in the `results` map, while `qualified` was `false` and `overall` was `fail`. The actual reason lived only in the `blocked_by` / `summary` prose.
- Because the counts were computed over that same 15-test list, such a build even read as **`15/15 passed` with `qualified: false`** which is a flat contradiction for anyone looking at the numbers.

---

### Why it happened

T0.5 was added to the Tier 0 runner later. It catches the hidden-`.kpack` drop, where `actions/upload-artifact` silently omits the per-gfx code objects (they ship in hidden dot-dirs) and produces a bundle that loads and enumerates the GPU but dies on the first kernel launch with `hipErrorInvalidImage`. The runner, the aggregator, and the promotion gate all already account for T0.5. Only `publish_qualification.py` — frozen against the original 15-test feed contract — was never updated to match.

---

### The fix

1. Add T0.5 to `TIER_TESTS["tier0"]`. The canonical suite is now **16 tests**, which is exactly what the tier runners execute. T0.5 now appears in the `results` map and the pass/fail counts, so a red T0.5 shows as a failed cell instead of hiding behind an all-green Tier 0 row.
2. No behavior other than the feed changes: the runner, aggregation, and promotion logic already ran and gated on T0.5. This only stops the published feed from dropping it.

---

### Schema version

Left at `1` on purpose. The entry shape (keys and types) is unchanged; this is additive - one new id in `results`, and `total` goes 15 → 16. 

---

### Files

- `scripts/publish_qualification.py` — added "T0.5" to TIER_TESTS["tier0"] (feed now 16); replaced the misleading "intentionally skips T0.5" comment with the real rationale; updated the module docstring (15→16).
- **`docs/qualification-feed.md`** — the published contract: `total` is now 16, the canonical id list includes T0.5, and the example entry reflects the new count/map.
- **`docs/dashboard-plan.md`** — 15 → 16 across the views, tiles, and count invariants.
- **`README.md`** — "15-test qualification" → "16-test qualification".
