### PR TITLE
Restrict 'Latest Release' to stable channel builds; mark nightly and omni as pre-releases

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -1145,8 +1145,19 @@ jobs:
         # Delete existing release with same tag (idempotent rebuilds)
         gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
 
+        # Channel gating: only stable is promoted to the repo's "latest" release;
+        # nightly and omni are published as prereleases. Lemonade's auto-bump reads
+        # /releases/latest for the stable pin and the newest non-omni prerelease for
+        # the nightly pin, so a nightly/omni tag can never leak into the stable key.
+        release_flags="--latest"
+        if [ "$OMNI" = "true" ] || [ "$CHANNEL" = "nightly" ]; then
+          release_flags="--prerelease"
+        fi
+        echo "Release flags: $release_flags (channel=$CHANNEL omni=$OMNI)"
+
         gh release create "$TAG" \
           --title "$TAG" \
+          $release_flags \
           --notes "**GPU Target**: $TARGET
         **vLLM Version**: $VLLM_VERSION
         **PyTorch Version**: $TORCH_VERSION

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,12 @@ It is **not** a place to fix, patch, or work around upstream bugs.
 
 Builds are produced on two channels (mirroring `llamacpp-rocm` /
 lemonade's `rocm_channel`). The **qualification suite is identical** for both,
-and **both promote prerelease → release only on a green qualification.**
+and a build is **published only on a green qualification**. On green the
+channels are marked differently so Lemonade's auto-bump can tell them apart:
+**stable** becomes the repo's `--latest` full release, while **nightly** (and
+omni) are published as GitHub **prereleases**. Lemonade reads `/releases/latest`
+for the stable pin and the newest non-omni prerelease for the nightly pin, so a
+nightly or omni tag can never surface as `latest` or leak into the stable pin.
 
 | Channel | What it is | Source | Expectation |
 |---------|-----------|--------|-------------|
@@ -24,8 +29,9 @@ and **both promote prerelease → release only on a green qualification.**
 | **nightly** | AMD's official nightly, date-stamp-matched by us | AMD's universal-RDNA nightly vLLM (`rocm.frameworks-nightlies.amd.com/whl/device-all-rdna`) + the AMD ROCm PyTorch carrying the same `rocm7.X.0a<DATE>` build stamp (`rocm.nightlies.amd.com/whl-multi-arch`) | Bleeding edge; **may legitimately be red** when the newest vLLM + ROCm aren't yet usable on the target GPU |
 
 A red nightly is a correct outcome, not a bug to fix: it reports that the
-newest AMD vLLM + ROCm aren't yet usable together on the target hardware. It
-stays a prerelease until it goes green on its own.
+newest AMD vLLM + ROCm aren't yet usable together on the target hardware. It is
+not published until it goes green on its own; a green nightly is published as a
+prerelease (never `latest`).
 
 ## Inviolable principles
 
@@ -36,7 +42,7 @@ stays a prerelease until it goes green on its own.
 
 2. **Do not attempt to fix a broken upstream release.** If AMD publishes a
    wheel that fails to load or run, the qualification suite **reports it as
-   broken** and the release stays a prerelease. We never carry a workaround.
+   broken** and the build is not published. We never carry a workaround.
    A red qualification is a correct, useful outcome — it tells AMD (and us)
    the release is not usable, with evidence.
 
@@ -56,11 +62,14 @@ stays a prerelease until it goes green on its own.
    channel's *definition*, not a reconciliation; if they mismatch, that is the
    true, reported result.)
 
-5. **Qualification gates promotion — both channels, green-only.** Every build
-   (stable and nightly) is published as a `prerelease` first and promoted to a
-   full release only when its target's qualification tiers pass. Failing builds
-   remain downloadable prereleases with their qualification report attached.
-   Lemonade only auto-discovers full releases.
+5. **Qualification gates publication; the channel decides the flag.** A build is
+   published only when its target's qualification tiers pass (a red build fails
+   the job and is not released). On green, the release flag is set by channel,
+   not by re-running qualification: **stable** → `--latest` (the repo's single
+   "latest" release), **nightly** and **omni** → `--prerelease`. This is what
+   keeps the channels distinguishable to consumers: Lemonade auto-discovers the
+   stable pin via `/releases/latest` and the nightly pin via the newest non-omni
+   prerelease, so nightly/omni can never masquerade as the stable pin.
 
 6. **Automation.** **nightly** runs automatically on a daily schedule: a
    `detect-nightly` job polls AMD's `device-all-rdna` index and dedups against
@@ -85,7 +94,7 @@ stays a prerelease until it goes green on its own.
   reconciliation to force an incompatible combination. This is the channel that
   surfaces breakage on the newest stack (e.g. a vLLM↔torch C++-ABI skew, or GPU
   kernels invalid for a target arch); the qualification suite reports it red and
-  it stays a prerelease. We never patch or swap a component to dodge that.
+  the build is not published. We never patch or swap a component to dodge that.
 
 ## Qualification suite
 
@@ -102,4 +111,5 @@ alter it to pass.
 - Do not patch vLLM, PyTorch, Triton, or ROCm.
 - Do not pin/swap component versions to dodge an upstream incompatibility.
 - Do not delete files during trim that the runtime needs.
-- Do not promote a release that did not pass qualification.
+- Do not publish a release that did not pass qualification.
+- Do not mark a nightly or omni build as `--latest`; only stable is `--latest`.

--- a/scripts/qualify/README.md
+++ b/scripts/qualify/README.md
@@ -1,10 +1,11 @@
 # Build qualification suite
 
-Tiered tests that gate a vllm-rocm build before its release tag is promoted from
-`prerelease` to a full release. Each tier emits a dashboard-friendly JSON
-fragment; `aggregate.py` merges them into one qualification record per build
-target, decides promotion, and appends the record to the `build-results` branch
-ledger (`results/ledger.jsonl`).
+Tiered tests that gate whether a vllm-rocm build is published at all: a build is
+released only when its required tiers pass. On green, the release flag is set by
+channel — **stable** → `--latest`, **nightly**/**omni** → `--prerelease`. Each
+tier emits a dashboard-friendly JSON fragment; `aggregate.py` merges them into
+one qualification record per build target, decides whether it qualifies, and
+appends the record to the `build-results` branch ledger (`results/ledger.jsonl`).
 
 | Tier | Where it runs | Catches | Gating |
 |------|---------------|---------|--------|
@@ -21,19 +22,25 @@ are recorded `hardware_validated: false`.
 
 `channel` is a **run-level** parameter (not a matrix axis) — stable and nightly
 have different triggers and different upstream sources, so they run as separate
-workflow runs. The qualification suite is identical for both, and **both promote
-only on green**.
+workflow runs. The qualification suite is identical for both, and **both publish
+only on green**. Tags carry **no channel suffix** (they are per-gfx-target only,
+e.g. `vllm0.22.1-rocm7.13.0-gfx1151`); the channel is distinguished by the
+GitHub release flag instead — stable is `--latest`, nightly/omni are
+`--prerelease`. This is what lets Lemonade's auto-bump keep the pins apart
+without parsing tags.
 
-| Channel | Source | Tag suffix | Notes |
+| Channel | Source | Release flag | Notes |
 |---------|--------|-----------|-------|
-| **stable** | AMD's matched vLLM + PyTorch (`rocm.frameworks.amd.com` + `repo.amd.com`) | `…-stable` | self-consistent; lags upstream vLLM |
-| **nightly** | latest vLLM (`wheels.vllm.ai/rocm`) + latest AMD ROCm PyTorch | `…-nightly` | bleeding edge; may be red when latest+latest are ABI-incompatible — reported, never patched |
+| **stable** | AMD's matched vLLM + PyTorch (`rocm.frameworks.amd.com` + `repo.amd.com`) | `--latest` | self-consistent; lags upstream vLLM |
+| **nightly** | latest vLLM (`wheels.vllm.ai/rocm`) + latest AMD ROCm PyTorch | `--prerelease` | bleeding edge; may be red when latest+latest are ABI-incompatible — reported, never patched |
 
 Every qualification record carries `build.channel`, so the dashboard can show a
-stable column and a nightly column per target. Consumers select a channel by tag
-suffix (`…-stable` / `…-nightly`), **not** GitHub's single "latest" pointer
-(which can't represent two channels), mirroring lemonade's
-`vllm.rocm-stable` / `vllm.rocm-nightly` keys.
+stable column and a nightly column per target. Consumers select a channel by the
+GitHub **release flag** — stable is the repo's `latest` full release, nightly is
+the newest non-omni prerelease — **not** by tag suffix (tags are per-gfx-target
+only). This maps onto lemonade's `vllm.rocm-stable` / `vllm.rocm-nightly` keys:
+its auto-bump reads `/releases/latest` for the stable pin and the newest
+non-omni prerelease for the nightly pin.
 
 ## What each tier looks for
 
@@ -106,8 +113,9 @@ allowed to call it:
    fast first pass set `gfx_target = gfx1151` and `create_release = true`.
    Scheduled runs default to `nightly`; `stable` is run on an AMD release (or
    manual dispatch with `channel=stable`).
-3. Flow: `build-ubuntu` → Tier 0 → `publish-prerelease` → `hw-qualify`
-   (Tier 1+2) → `tier3` (lemonade) → `aggregate` (promote on pass) → `ledger`.
+3. Flow: `build-ubuntu` → Tier 0 → `hw-qualify` (Tier 1+2) → `aggregate`
+   (`--fail-on-no-promote` gates the job) → **Create Release** (stable →
+   `--latest`, nightly/omni → `--prerelease`) → `ledger`.
 4. Review: the per-job **Step Summary** table, the `qualification-record-*`
    artifact, and `results/ledger.jsonl` on the `build-results` branch.
 


### PR DESCRIPTION
## Summary

Marks the release channels differently on publish so downstream consumers can tell them apart: **stable** is promoted to the repo's `--latest` release, while **nightly** and **omni** are published as GitHub **prereleases**.

Previously every green build was created as a full release with no flag, so `GET /releases/latest` returned whichever build happened to publish last — often a nightly or omni build.

Lemonade's auto-bump reads that endpoint, which is exactly why it kept mis-pinning the vLLM ROCm backend to nightly/omni tags (see`lemonade` class of bad auto-PRs [#2757](https://github.com/lemonade-sdk/lemonade/pull/2757) / [#3178](https://github.com/lemonade-sdk/lemonade/pull/3178)).

This is a one-line-of-logic change in the release step plus the docs that describe the contract.

---

## Why this change / how it ties to lemonade

Lemonade is splitting `vllm:rocm` into **stable** and **nightly** channels ([#3334](https://github.com/lemonade-sdk/lemonade/pull/3334), branch `sreeram/vllm-rocm-channels`). Its auto-bump resolves:

| Lemonade pin | Resolves from |
|---|---|
| `vllm.rocm-stable` | `GET /releases/latest` |
| `vllm.rocm-nightly` | newest **non-omni prerelease** |

That resolution only works if this repo actually flags its releases. **This PR is the precondition for that lemonade branch** — without it, `/releases/latest` is not stable-only and the two channels are indistinguishable. 

**This PR should be merged first.**

The qualification contract is unchanged: a build is still published **only** on a green qualification. All this changes is the *flag* set on an already-qualified build — it is not a second gate.

---

## Files changed

| File | What changed |
|---|---|
| `.github/workflows/build-vllm-rocm.yml` | In the `gh release create` step, set the flag by channel: `stable` → `--latest`, `nightly`/`omni` → `--prerelease`. |
| `CLAUDE.md` | Update the channel model: publication is gated by qualification; the channel decides the flag (stable = `--latest`, nightly/omni = prerelease). Add the invariant "never mark nightly/omni as `--latest`." |
| `scripts/qualify/README.md` | Reword so qualification gates *publication*, and on green the flag is set by channel. |

---

## One-time cleanup completed

Existing nightly/omni releases were created as full releases, so a stale one can still sit as `latest`. Re-flagged them as `prereleases` so `/releases/latest` cleanly returns only the stable builds.

---

## Testing

_Testing details:_ Dispatch a stable build → lands as `latest`; dispatch a nightly and an omni build → both land as prereleases; confirm `GET /releases/latest` returns the stable tag. (Validate alongside the lemonade `validate_vllm.yml` dry-run.)