### PR TITLE
Fix stranded Triton JIT compiler + harden self-hosted build disk

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -273,32 +273,22 @@ jobs:
 
     - name: Reclaim disk space (self-hosted hygiene)
       run: |
-        # This job runs on the PERSISTENT dev_lab box shared with qualify, not a
-        # fresh GitHub-hosted VM — leftovers survive between runs and eventually
-        # exhaust the disk (the stable install died with ENOSPC while writing the
-        # 602 MB rocm-sdk-libraries wheel). Reclaim before every build:
-        #   - the legacy persistent pip cache (we now install with
-        #     PIP_NO_CACHE_DIR=1, so ~/.cache/pip only ever shrinks from here)
-        #   - stale build trees from prior/crashed runs (a run that dies on ENOSPC
-        #     never reaches this job's end-of-job cleanup)
-        # ---- TEMPORARY debug: what/where is filling up? Remove once diagnosed. --
-        # $RUNNER_TEMP lives on the big work partition, but pip's cache (~/.cache)
-        # and build temp ($TMPDIR/tmp) may sit on a SMALLER partition — that, not
-        # the 1.7T work disk, is the likely ENOSPC culprit. Show every mount that
-        # matters + which box we're on, so we can prove which filesystem fills.
-        echo "=== runner: ${RUNNER_NAME:-?}  TMPDIR=${TMPDIR:-/tmp} ==="
-        echo "=== Disk BEFORE cleanup (all relevant mounts) ==="
-        df -h / /tmp "$HOME" "$HOME/.cache" "$RUNNER_TEMP" 2>/dev/null || true
-        echo "--- top consumers in HOME cache + RUNNER_TEMP ---"
-        du -sh "$HOME/.cache/pip"          2>/dev/null || true
-        du -sh "$HOME/.cache/huggingface"  2>/dev/null || true
-        du -sh "$RUNNER_TEMP"/vllm-build*  2>/dev/null || true
-        du -sh "$RUNNER_TEMP"/* 2>/dev/null | sort -rh | head -20 || true
-        # -------------------------------------------------------------------------
+        # This job runs on the PERSISTENT dev_lab box, where ~/.cache and /tmp live
+        # on a SMALL ~32G root overlay ("/") — the 1.7T nvme is only the runner work
+        # dir ($RUNNER_TEMP), NOT where pip caches.
+        # pip's default wheel cache grew on that 32G root across the daily nightly runs 
+        # until it hit ~93% full and an install died with ENOSPC ([Errno 28]) mid-download.
+        # We now install with PIP_NO_CACHE_DIR=1 (no new cache is ever written) and reclaim
+        # before every build so the root overlay stays healthy:
+        #   - the legacy pip cache on root (only ever shrinks from here)
+        #   - stale build trees from prior/crashed runs (a run that dies on ENOSPC never reaches this job's end-of-job cleanup)
+        # NB: ~/.cache/huggingface (qualify's model weights) also lives on root —
+        # we deliberately leave it (deleting forces slow re-downloads);
+        # watch it if root pressure returns.
+        echo "=== Disk BEFORE cleanup ==="; df -h / "$RUNNER_TEMP" || true
         rm -rf "$HOME/.cache/pip"         2>/dev/null || true
         rm -rf "$RUNNER_TEMP"/vllm-build* 2>/dev/null || true
-        echo "=== Disk AFTER cleanup (all relevant mounts) ==="
-        df -h / /tmp "$HOME" "$HOME/.cache" "$RUNNER_TEMP" 2>/dev/null || true
+        echo "=== Disk AFTER cleanup ===";  df -h / "$RUNNER_TEMP" || true
 
     - name: Download portable Python (python-build-standalone)
       run: |

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -56,6 +56,13 @@ env:
   # have different triggers and different upstream sources, so they run as
   # separate workflow runs. Scheduled runs default to nightly.
   CHANNEL: ${{ github.event.inputs.channel || 'nightly' }}
+  # build-ubuntu runs on the PERSISTENT dev_lab self-hosted box (not a fresh VM),
+  # so pip's default on-disk wheel cache (~/.cache/pip) is never reclaimed and
+  # grows unbounded across the daily nightly runs until an install dies with
+  # ENOSPC ([Errno 28] No space left on device) mid-download. The cross-run
+  # cache buys us nothing here (each wheel is installed once per run), so disable
+  # it globally: pip streams wheels straight to the install and keeps no copy.
+  PIP_NO_CACHE_DIR: "1"
   # When true, layer vLLM-Omni on top of the base bundle (built on the same
   # channel) and release it as a separate vllm-omni* artifact. vLLM-Omni is a
   # pure-Python layer; the omni bundle is the base bundle + vllm-omni + its deps
@@ -263,6 +270,28 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+
+    - name: Reclaim disk space (self-hosted hygiene)
+      run: |
+        # This job runs on the PERSISTENT dev_lab box shared with qualify, not a
+        # fresh GitHub-hosted VM — leftovers survive between runs and eventually
+        # exhaust the disk (the stable install died with ENOSPC while writing the
+        # 602 MB rocm-sdk-libraries wheel). Reclaim before every build:
+        #   - the legacy persistent pip cache (we now install with
+        #     PIP_NO_CACHE_DIR=1, so ~/.cache/pip only ever shrinks from here)
+        #   - stale build trees from prior/crashed runs (a run that dies on ENOSPC
+        #     never reaches this job's end-of-job cleanup)
+        echo "=== Disk BEFORE cleanup ==="; df -h "$RUNNER_TEMP" || true
+        # ---- TEMPORARY debug: what is eating the disk? Remove once diagnosed. ----
+        echo "--- top consumers in HOME cache + RUNNER_TEMP ---"
+        du -sh "$HOME/.cache/pip"          2>/dev/null || true
+        du -sh "$HOME/.cache/huggingface"  2>/dev/null || true
+        du -sh "$RUNNER_TEMP"/vllm-build*  2>/dev/null || true
+        du -sh "$RUNNER_TEMP"/* 2>/dev/null | sort -rh | head -20 || true
+        # -------------------------------------------------------------------------
+        rm -rf "$HOME/.cache/pip"         2>/dev/null || true
+        rm -rf "$RUNNER_TEMP"/vllm-build* 2>/dev/null || true
+        echo "=== Disk AFTER cleanup ==="; df -h "$RUNNER_TEMP" || true
 
     - name: Download portable Python (python-build-standalone)
       run: |

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -281,8 +281,14 @@ jobs:
         #     PIP_NO_CACHE_DIR=1, so ~/.cache/pip only ever shrinks from here)
         #   - stale build trees from prior/crashed runs (a run that dies on ENOSPC
         #     never reaches this job's end-of-job cleanup)
-        echo "=== Disk BEFORE cleanup ==="; df -h "$RUNNER_TEMP" || true
-        # ---- TEMPORARY debug: what is eating the disk? Remove once diagnosed. ----
+        # ---- TEMPORARY debug: what/where is filling up? Remove once diagnosed. --
+        # $RUNNER_TEMP lives on the big work partition, but pip's cache (~/.cache)
+        # and build temp ($TMPDIR/tmp) may sit on a SMALLER partition — that, not
+        # the 1.7T work disk, is the likely ENOSPC culprit. Show every mount that
+        # matters + which box we're on, so we can prove which filesystem fills.
+        echo "=== runner: ${RUNNER_NAME:-?}  TMPDIR=${TMPDIR:-/tmp} ==="
+        echo "=== Disk BEFORE cleanup (all relevant mounts) ==="
+        df -h / /tmp "$HOME" "$HOME/.cache" "$RUNNER_TEMP" 2>/dev/null || true
         echo "--- top consumers in HOME cache + RUNNER_TEMP ---"
         du -sh "$HOME/.cache/pip"          2>/dev/null || true
         du -sh "$HOME/.cache/huggingface"  2>/dev/null || true
@@ -291,7 +297,8 @@ jobs:
         # -------------------------------------------------------------------------
         rm -rf "$HOME/.cache/pip"         2>/dev/null || true
         rm -rf "$RUNNER_TEMP"/vllm-build* 2>/dev/null || true
-        echo "=== Disk AFTER cleanup ==="; df -h "$RUNNER_TEMP" || true
+        echo "=== Disk AFTER cleanup (all relevant mounts) ==="
+        df -h / /tmp "$HOME" "$HOME/.cache" "$RUNNER_TEMP" 2>/dev/null || true
 
     - name: Download portable Python (python-build-standalone)
       run: |

--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -677,18 +677,55 @@ jobs:
 
         # Trim LLVM toolchain: keep only clang + its libs (~350MB saved)
         LLVM="$SP/_rocm_sdk_core/lib/llvm"
-        # Keep the clang driver and its versioned binary (clang-NN). The LLVM
-        # major tracks the ROCm release (clang-22 on 7.13, clang-23 on 7.14);
-        # hardcoding clang-22 would delete the real compiler on newer ROCm and
-        # break Triton's runtime JIT. Match clang-* so it survives any version.
+        # Keep the clang driver AND its versioned exec target (clang-NN).
+        
+        # When invoked as the unversioned `clang`, the driver resolves /proc/self/exe
+        # and re-execs `clang-<major>` to do the actual compile, so deleting the
+        # versioned binary strands the driver and breaks Triton's runtime JIT.
+        
+        # The LLVM major tracks the ROCm release and is NOT knowable ahead of
+        # time, so match clang-* rather than a hardcoded version. 
+        
+        # clang-NN can be shipped as a real file OR a symlink depending on the wheel,
+        # so BOTH passes must spare clang-* — the symlink pass previously kept only `clang` and so
+        # deleted a clang-NN *symlink*, stranding the driver (issues #16/#19/#40).
+        
         find "$LLVM/bin" -type f ! -name "clang" ! -name "clang-*" -delete 2>/dev/null || true
-        find "$LLVM/bin" -type l ! -name "clang" -delete 2>/dev/null || true
+        find "$LLVM/bin" -type l ! -name "clang" ! -name "clang-*" -delete 2>/dev/null || true
         # Keep only libs that clang needs (libclang-cpp, libLLVM, rocm_sysdeps)
         find "$LLVM/lib" -name "*.so*" \
           ! -name "libclang-cpp*" \
           ! -name "libLLVM*" \
           -delete 2>/dev/null || true
         rm -rf "$LLVM/lib/clang/"*/include/cuda_wrappers 2>/dev/null || true
+
+        # Fail the build if the trim stranded the compiler.
+        # The launcher exports CC=this clang, so Triton compiles its
+        # per-kernel __triton_launcher.c with exactly this driver at model load;
+        # reproduce that compile here, on the build box, with no GPU needed.
+        if [ -e "$LLVM/bin/clang" ]; then
+          chmod +x "$LLVM/bin/"clang* 2>/dev/null || true
+          # LLVM major = the resource dir the wheel ships (authoritative even if the driver itself can't run yet): lib/clang/<major>/.
+          MAJOR=$(basename "$(ls -d "$LLVM/lib/clang"/*/ 2>/dev/null | head -1)" 2>/dev/null || true)
+          if [ -n "$MAJOR" ] && [ ! -e "$LLVM/bin/clang-$MAJOR" ]; then
+            echo "::error::LLVM trim stranded clang-$MAJOR (the clang driver re-execs it for Triton JIT)"
+            ls -la "$LLVM/bin" || true
+            exit 1
+          fi
+          # End-to-end: the driver must resolve its clang-NN and produce a shared object from a trivial C source — exactly Triton's launcher compile.
+          echo 'int main(void){return 0;}' > /tmp/cc_probe.c
+          if ! LD_LIBRARY_PATH="$LLVM/lib:$SP/_rocm_sdk_core/lib:${LD_LIBRARY_PATH:-}" \
+               "$LLVM/bin/clang" -shared -fPIC -O3 -o /tmp/cc_probe.so /tmp/cc_probe.c 2>/tmp/cc_probe.err; then
+            echo "::error::bundled clang cannot compile after trim — Triton JIT would fail at model load"
+            cat /tmp/cc_probe.err || true
+            ls -la "$LLVM/bin" || true
+            exit 1
+          fi
+          echo "bundled clang OK: driver + clang-$MAJOR present, stub -shared -fPIC compile succeeded"
+          rm -f /tmp/cc_probe.c /tmp/cc_probe.so /tmp/cc_probe.err
+        else
+          echo "::warning::no bundled clang under $LLVM/bin — Triton JIT will need a system compiler"
+        fi
 
         # Trim ROCm SDK bin/ (Python wrapper scripts, not needed)
         rm -rf "$SP/_rocm_sdk_core/bin" 2>/dev/null || true
@@ -926,14 +963,14 @@ jobs:
         # No sudo — it's under the runner's temp dir. Free the box for the next run.
         rm -rf "$RUNNER_TEMP/vllm-build" || true
 
-  # 16-test qualification, one leg per selected target that has qualification
+  # 17-test qualification, one leg per selected target that has qualification
   # hardware (prepare-matrix qualify_matrix: target -> self-hosted runner group;
   # currently gfx1151 -> dev_lab). Targets the runner GROUP (not just labels) so
   # a leg can't land on a Linux box in another group the repo can also see
   # (Default is visibility:all) — see build-ubuntu.
   # Runs the scripts/qualify harness against the built bundle:
-  #   tier0 static (6) + tier1 hardware smoke (5) + tier2 functional inference (5)
-  # = 16 tests, then aggregates them into a qualification report and a promotion
+  #   tier0 static (7) + tier1 hardware smoke (5) + tier2 functional inference (5)
+  # = 17 tests, then aggregates them into a qualification report and a promotion
   # decision. Releases are gated on promotion (see create-release `needs`).
   qualify:
     needs: [prepare-matrix, build-ubuntu]
@@ -1053,7 +1090,7 @@ jobs:
           if [ ! -e "$link" ]; then ln -sf "$name" "$link"; fi
         done
 
-    - name: Run 16-test qualification (tier0 + tier1 + tier2)
+    - name: Run 17-test qualification (tier0 + tier1 + tier2)
       id: qual
       run: |
         WORK="${{ runner.temp }}/vllm-qual"
@@ -1070,7 +1107,7 @@ jobs:
         # The tiers are run WITHOUT --fail-on-error so all 16 tests execute and
         # emit a JSON fragment even when one fails; `aggregate --fail-on-no-promote`
         # is the single gate that decides pass/fail for the whole job.
-        echo "::group::Tier 0 — static bundle verification (T0.1–T0.6)"
+        echo "::group::Tier 0 — static bundle verification (T0.1–T0.7)"
         "$PY" "$Q/tier0_static.py"   --bundle-root "$ROOT" --gfx-target "$GFX" \
             --channel "$CHANNEL" --candidate-tag "$TAG" --output "$FRAG/tier0-report.json" || true
         echo "::endgroup::"

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Our GitHub Actions workflow:
 - Installs **PyTorch ROCm** from AMD's pip index (`https://repo.amd.com/rocm/whl/<target>/`)
 - Installs **vLLM ROCm** (pre-built wheel) from AMD's vLLM wheel index (`https://wheels.vllm.ai/rocm/`), which pulls the matching `rocm-sdk-core` and `rocm-sdk-libraries-gfx<target>` wheels as transitive deps
 - Generates a `bin/vllm-server` shim that wires up `LD_LIBRARY_PATH` / `PYTHONPATH` at startup
-- Runs a **16-test qualification** on the **gfx1151** build on self-hosted AMD GPU hardware (Strix Halo) — Tier 0 static bundle checks, Tier 1 hardware smoke, Tier 2 functional inference — aggregates the results into a qualification report, and gates all releases on the build being promotable (see [`scripts/qualify`](scripts/qualify/README.md))
+- Runs a **17-test qualification** on the **gfx1151** build on self-hosted AMD GPU hardware (Strix Halo) — Tier 0 static bundle checks, Tier 1 hardware smoke, Tier 2 functional inference — aggregates the results into a qualification report, and gates all releases on the build being promotable (see [`scripts/qualify`](scripts/qualify/README.md))
 - Tars the result, splits it into `< 2 GB` parts, and publishes the release
 
 | GPU Target | Ubuntu |

--- a/docs/qualification-feed.md
+++ b/docs/qualification-feed.md
@@ -69,12 +69,12 @@ field so re-runs are visible, but they don't fork the record — the dashboard a
       "vllm_version": "0.22.1+rocm722",
       "torch_version": "2.11.0+rocm7.13.0",
       "rocm_version": "7.13.0",
-      "tests": { "passed": 8, "failed": 8, "warned": 0, "skipped": 0, "total": 16 },
+      "tests": { "passed": 9, "failed": 8, "warned": 0, "skipped": 0, "total": 17 },
       "qualified": false,                      // == promoted; "did it qualify to release"
       "overall": "fail",                       // pass | fail | warn
       "blocked_by": ["tier0=fail", "tier1=fail", "tier2 missing"],
-      "results": {                             // per-test status across the 16-test suite
-        "T0.1": "fail", "T0.2": "fail", "T0.3": "pass", "T0.4": "pass", "T0.5": "pass", "T0.6": "pass",
+      "results": {                             // per-test status across the 17-test suite
+        "T0.1": "fail", "T0.2": "fail", "T0.3": "pass", "T0.4": "pass", "T0.5": "pass", "T0.6": "pass", "T0.7": "pass",
         "T1.1": "fail", "T1.2": "pass", "T1.3": "pass", "T1.4": "pass", "T1.5": "pass",
         "T2.1": "missing", "T2.2": "missing", "T2.3": "missing", "T2.4": "missing", "T2.5": "missing"
       },
@@ -92,12 +92,12 @@ field so re-runs are visible, but they don't fork the record — the dashboard a
 
 ### Field notes
 
-- **`tests.total` is always 16** (the canonical suite). A tier that produced no
+- **`tests.total` is always 17** (the canonical suite). A tier that produced no
   fragment (e.g. Tier 2 when the server failed to boot) has its tests marked
   `"missing"` in `results` and **counted as `failed`**. So `passed + failed +
-  warned + skipped == 16` always, and the counts never look misleadingly small.
+  warned + skipped == 17` always, and the counts never look misleadingly small.
 - **`results`** values are one of `pass | fail | warn | skip | missing`. Test ids are
-  the canonical 16: T0.1–T0.6, T1.1–T1.5, T2.1–T2.5. This lets the dashboard
+  the canonical 17: T0.1–T0.7, T1.1–T1.5, T2.1–T2.5. This lets the dashboard
   compute failure-frequency and heatmap views from `index.json` alone (no N+1 fetch).
 - **`qualified`** is the release gate (`true` only if every required tier passed).
 - **`report_url`** is relative to the feed base — open it for the full per-test

--- a/scripts/publish_qualification.py
+++ b/scripts/publish_qualification.py
@@ -11,7 +11,7 @@ and writes, under --data-dir (the `qualification/` dir on the data branch):
 
 The index entry is keyed by build_id, so re-running this for the same build is
 an idempotent upsert (no duplicate rows/files). Counts are normalized to the
-canonical 16-test suite: a tier that produced no fragment (e.g. Tier 2 when the
+canonical 17-test suite: a tier that produced no fragment (e.g. Tier 2 when the
 server failed to boot) has its tests marked "missing" and folded into `failed`,
 so the dashboard never shows a misleadingly small total.
 
@@ -23,13 +23,13 @@ from pathlib import Path
 
 SCHEMA_VERSION = 1
 
-# The canonical 16-test suite, mirroring exactly what the tier runners execute.
+# The canonical 17-test suite, mirroring exactly what the tier runners execute.
 TIER_TESTS = {
-    "tier0": ["T0.1", "T0.2", "T0.3", "T0.4", "T0.5", "T0.6"],
+    "tier0": ["T0.1", "T0.2", "T0.3", "T0.4", "T0.5", "T0.6", "T0.7"],
     "tier1": ["T1.1", "T1.2", "T1.3", "T1.4", "T1.5"],
     "tier2": ["T2.1", "T2.2", "T2.3", "T2.4", "T2.5"],
 }
-TOTAL_TESTS = sum(len(v) for v in TIER_TESTS.values())  # 16
+TOTAL_TESTS = sum(len(v) for v in TIER_TESTS.values())  # 17
 
 
 def _int(v):

--- a/scripts/qualify/README.md
+++ b/scripts/qualify/README.md
@@ -8,7 +8,7 @@ ledger (`results/ledger.jsonl`).
 
 | Tier | Where it runs | Catches | Gating |
 |------|---------------|---------|--------|
-| 0 static | hosted build runner (no GPU) | torch ABI / version-pin mismatch, missing native exts, broken launcher | yes |
+| 0 static | hosted build runner (no GPU) | torch ABI / version-pin mismatch, missing native exts, broken launcher, stranded clang (Triton JIT) | yes |
 | 1 smoke | gfx1151 self-hosted | native ext won't dlopen, platform import crash, GPU not visible | yes |
 | 2 inference | gfx1151 self-hosted | server won't boot, broken Triton JIT, dead endpoints | yes |
 | 3 lemonade | gfx1151 self-hosted (reusable workflow in lemonade) | install path, recipe registry, real-model load+chat | yes |
@@ -37,22 +37,36 @@ suffix (`…-stable` / `…-nightly`), **not** GitHub's single "latest" pointer
 
 ## What each tier looks for
 
+### Tier 0
 - **T0.1** vLLM's `Requires-Dist: torch==` release == the bundled torch release.
-- **T0.2** every undefined `c10::`/`at::`/`torch::` symbol in `_C.abi3.so` /
-  `_rocm_C.abi3.so` is defined by a bundled torch/ROCm lib.
-- **T0.3** DT_NEEDED sonames resolve in-bundle (warn). **T0.4** required files +
-  launcher syntax. **T0.6** bundled amdsmi present.
+- **T0.2** every undefined `c10::`/`at::`/`torch::` symbol in `_C.abi3.so` / `_rocm_C.abi3.so` is defined by a bundled torch/ROCm lib.
+- **T0.3** DT_NEEDED sonames resolve in-bundle (warn). 
+- **T0.4** required files + launcher syntax. 
+- **T0.6** bundled amdsmi present. 
+- **T0.7** the bundled clang the launcher exports as `CC` resolves its `clang-NN` exec target and compiles a
+  `-shared -fPIC` stub — the exact Triton launcher-compile path, checked
+  statically so a stranded compiler can't ship green.
+
+### Tier 1
 - **T1.1** `import vllm._C, vllm._rocm_C`. **T1.2** `from vllm.platforms import
-  current_platform`. **T1.3** torch.cuda sees the GPU + gcnArchName. **T1.4**
-  amdsmi ASIC read (warn). **T1.5** `vllm-server --help`.
-- **T2.1** server boots. **T2.2** non-empty completion. **T2.3** greedy
-  determinism. **T2.4** chat. **T2.5** streaming.
+  current_platform`. 
+- **T1.3** torch.cuda sees the GPU + gcnArchName. 
+- **T1.4** amdsmi ASIC read (warn). 
+- **T1.5** `vllm-server --help`.
+
+### Tier 2
+- **T2.1** server boots. **T2.2** non-empty completion. 
+- **T2.3** greedy determinism. 
+- **T2.4** chat. 
+- **T2.5** streaming.
 - **Omni variant** (`tier2_omni.py`, run *instead of* `tier2_inference.py` on
   builds made with the workflow's `omni: true` input): boots `vllm-omni-server`
   on `Qwen2.5-Omni-3B` with a single-GPU deploy config
   (`deploy/qwen2_5_omni_1gpu.yaml`) and checks **T2.1** omni server boot,
   **T2.2** chat completion, **T2.3** streaming. Emits the same `tier2` fragment,
   so promotion (`--require-tiers tier0,tier1,tier2`) is unchanged.
+
+### Tier 3
 - **T3.n** lemonade installs the candidate and each hot vLLM model loads + chats;
   tokens/sec and TTFT captured as metrics.
 

--- a/scripts/qualify/tier0_static.py
+++ b/scripts/qualify/tier0_static.py
@@ -26,6 +26,11 @@ Checks:
         hipErrorInvalidImage. This static check catches that drop before the
         hardware tiers (and before release).
   T0.6  amdsmi path sanity             — bundled amdsmi package is present.
+  T0.7  clang toolchain can compile    — the bundled clang the launcher exports
+        as CC exists, resolves its versioned clang-NN exec target, reports a
+        version, and compiles a trivial `-shared -fPIC` stub. This reproduces
+        Triton's per-kernel __triton_launcher.c build statically and with no GPU, 
+        so a hollow compiler can't ship green.
 
 Usage:
     python tier0_static.py --bundle-root /opt/vllm \
@@ -402,6 +407,110 @@ def check_amdsmi_path(sp):
     return (report.STATUS_PASS, None, details)
 
 
+def _llvm_dir(sp):
+    return os.path.join(sp, "_rocm_sdk_core", "lib", "llvm")
+
+
+def _clang_ld_library_path(sp):
+    """The lib dirs the launcher puts on LD_LIBRARY_PATH so clang can run."""
+    parts = [
+        os.path.join(_llvm_dir(sp), "lib"),
+        os.path.join(sp, "_rocm_sdk_core", "lib"),
+    ]
+    existing = os.environ.get("LD_LIBRARY_PATH", "")
+    if existing:
+        parts.append(existing)
+    return ":".join(p for p in parts if p)
+
+
+def _clang_major(llvm):
+    """LLVM major from the authoritative resource dir lib/clang/<major>/.
+
+    Read from the shipped resource dir (not `clang --version`) so it is known
+    even when the driver itself can't run yet — which is exactly the failure
+    this check exists to detect.
+    """
+    for path in sorted(glob.glob(os.path.join(llvm, "lib", "clang", "*"))):
+        name = os.path.basename(path.rstrip(os.sep))
+        if name.isdigit():
+            return name
+    return None
+
+
+def check_clang_toolchain(sp):
+    """T0.7 — the bundled clang the launcher exports as CC must actually compile.
+
+    The launcher (build-vllm-rocm.yml) sets `CC=$SP/_rocm_sdk_core/lib/llvm/bin/
+    clang`, and Triton shells out to `$CC` to build each kernel's
+    __triton_launcher.c at model load. When the LLVM-trim step strands the
+    versioned `clang-NN` the driver re-execs, that compile dies with
+    "could not exec .../clang-NN: No such file or directory" — a bundle that
+    still passes every other gate (the older tiers never invoke the compiler).
+    Reproduce the exact compile here, statically and with no GPU.
+    """
+    llvm = _llvm_dir(sp)
+    clang = os.path.join(llvm, "bin", "clang")
+    details: dict = {"clang": clang}
+
+    if not os.path.isdir(llvm):
+        # No bundled LLVM toolchain at all — nothing we packaged to verify.
+        return (report.STATUS_SKIP, "no bundled LLVM toolchain under _rocm_sdk_core", details)
+    if not os.path.exists(clang):
+        # The launcher hardcodes CC to this path, so its absence is fatal.
+        return (report.STATUS_FAIL, "bundled clang driver missing (launcher exports it as CC)", details)
+
+    major = _clang_major(llvm)
+    details["llvm_major"] = major
+    versioned = os.path.join(llvm, "bin", f"clang-{major}") if major else None
+    details["clang_versioned"] = versioned
+    if versioned and not os.path.exists(versioned):
+        return (
+            report.STATUS_FAIL,
+            f"clang driver present but its exec target clang-{major} is missing "
+            "(stranded by the LLVM trim — Triton JIT will fail at model load)",
+            details,
+        )
+
+    env = dict(os.environ)
+    env["LD_LIBRARY_PATH"] = _clang_ld_library_path(sp)
+
+    ver = subprocess.run(
+        [clang, "--version"], capture_output=True, text=True, env=env, check=False
+    )
+    details["version_rc"] = ver.returncode
+    if ver.returncode != 0:
+        details["version_stderr"] = (ver.stderr or "").strip()[-400:]
+        return (report.STATUS_FAIL, f"`clang --version` exited {ver.returncode}", details)
+    details["version"] = (ver.stdout or "").strip().splitlines()[:1]
+
+    # The real test: compile a trivial C source to a shared object exactly the
+    # way Triton's runtime build.py drives CC for __triton_launcher.c.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        src = os.path.join(tmp, "cc_probe.c")
+        out = os.path.join(tmp, "cc_probe.so")
+        with open(src, "w", encoding="utf-8") as handle:
+            handle.write("int probe(void){return 0;}\n")
+        comp = subprocess.run(
+            [clang, "-shared", "-fPIC", "-O3", "-o", out, src],
+            capture_output=True, text=True, env=env, check=False,
+        )
+        details["compile_rc"] = comp.returncode
+        produced = os.path.exists(out) and os.path.getsize(out) > 0
+        details["compiled_so"] = produced
+        if comp.returncode != 0 or not produced:
+            details["compile_stderr"] = (comp.stderr or "").strip()[-400:]
+            return (
+                report.STATUS_FAIL,
+                "bundled clang could not compile a `-shared -fPIC` stub "
+                "(the Triton launcher-compile path) — bundle is unusable for JIT",
+                details,
+            )
+
+    return (report.STATUS_PASS, None, details)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Tier 0 static bundle verification")
     parser.add_argument(
@@ -467,6 +576,11 @@ def main():
     )
     tier.run(
         "T0.6", "amdsmi path sanity", lambda: check_amdsmi_path(sp), gating=False
+    )
+    tier.run(
+        "T0.7",
+        "clang toolchain can compile",
+        lambda: check_clang_toolchain(sp),
     )
 
     tier.write(args.output)


### PR DESCRIPTION
## What this does

Two independent problems surfaced from the shipped `vllm0.22.1-rocm7.13.0` stable RDNA line (gfx1151,gfx1150,gfx110X,gfx120X) builds. This branch fixes both issues and adds a gate so neither can silently ship again.

### 1. Stranded clang broke Triton's runtime JIT (the main fix)

At model load, Triton writes a small C launcher and compiles it with the clang we bundle. Our size-trim step was deleting the *real* versioned compiler (`clang-<major>`) and keeping only the thin `clang` driver, so that compile blew up the first time a model actually ran a Triton kernel. The archive shipped **green but unusable** because nothing in the pipeline ever exercised a JIT compile.

**Root cause:** the trim's file-pass already spared `clang-*` (fixed earlier in #9), but the **symlink-pass** still deleted `clang-<major>` when it shipped as a symlink. So the compiler could still be stranded depending on how a given ROCm wheel was laid out.

The fix is two-sided:
- **Stop stranding it** — spare `clang-*` in *both* the file and symlink passes, and add a build-side self-check that actually compiles a `-shared -fPIC` stub with the bundled clang (deriving the LLVM major dynamically from `lib/clang/<major>/`, no hardcoded version). If it can't compile, the build fails before a release is ever cut.
- **Close the gate** — new Tier 0 check **T0.7** runs the exact launcher-compile path statically (no GPU) during qualification, so a stranded toolchain can never pass green again. Suite is now 17 tests (was 16).

### 2. Build ENOSPC on the self-hosted runner

The stable install kept dying with `No space left on device` while pip wrote the big ROCm wheels. Turned out the dev_lab box has a **32 GB root overlay** (holding `~/.cache/pip` and `/tmp`) separate from the 1.7 TB runner work disk — and pip's cache had grown on that small root across the daily nightly runs until it hit 93 % full. Nightly passing while stable failed was just luck of free space, not a channel difference.

**Fix**: disable pip's on-disk cache workflow-wide (`PIP_NO_CACHE_DIR=1`) and reclaim the legacy cache + stale build trees at the start of every build. Confirmed: the reaper drops root from 93 % → 51 % and both runners now build cleanly.

## Files changed

| File | What changed |
|------|--------------|
| `.github/workflows/build-vllm-rocm.yml` | Spare `clang-*` in the symlink trim pass; add build-side clang compile self-check; add `PIP_NO_CACHE_DIR=1` + a "reclaim disk space" step (pip cache + stale build-tree reaper with before/after `df`); comment/string bumps to 17-test suite |
| `scripts/qualify/tier0_static.py` | New gating check **T0.7** — verifies the bundled clang resolves its `clang-<major>` and compiles a stub (the Triton launcher path); helpers to locate the LLVM dir and derive the major dynamically |
| `scripts/publish_qualification.py` | Register `T0.7` in the tier0 test set; 16 → 17 |
| `docs/qualification-feed.md` | Document T0.7; total 16 → 17 in the feed contract/examples |
| `scripts/qualify/README.md` | Add T0.7 description + "stranded clang (Triton JIT)" to the tier0 row |
| `README.md` | "16-test" → "17-test qualification" |

## Testing (dispatched stable / gfx1151 from this branch)

| Check | Result |
|-------|--------|
| `build-ubuntu (gfx1151)` | ✅ Passes on both runners (D01 + D02) after the disk fix |
| Disk reclaim | ✅ Root overlay 93 % → 51 %; ENOSPC gone |
| **T0.7 clang toolchain can compile** | ✅ **PASS on gfx1151 hardware — confirms the stranded-clang fix** |
| T0.2 / T1.1 (and downstream T1.5, T2.1) | ❌ Red — pre-existing, documented **AMD stable ABI skew** (`c10::…[abi:cxx11]` unresolved: AMD's stable vLLM and torch wheels built with different `_GLIBCXX_USE_CXX11_ABI`), **kin to #19 Defect 2, not regressed by this branch** |

The T0.2 red is a correct upstream result, not something we fix: per repo policy we repackage AMD's set faithfully and let qualification report the skew. That build stays a prerelease with its report attached and goes green on its own once AMD ships a matched-ABI stable pair.

Workflow run for reference: https://github.com/lemonade-sdk/vllm-rocm/actions/runs/32940620730

## Closes

- Closes #40
- Closes #16

## Not in scope (intentionally)

- No patching/pinning around the AMD stable ABI skew (T0.2) — reported, not worked around.
- A tier-1 forced `@triton.jit` GPU compile is a nice future add for defense-in-depth, but T0.7 + the build self-check already close the shipping hole, so it's left for a separate PR.
