### PR TITLE
Move build-ubuntu and qualify to the DevLab ephemeral pool

### DIFF
--- a/.github/workflows/build-vllm-rocm.yml
+++ b/.github/workflows/build-vllm-rocm.yml
@@ -192,19 +192,23 @@ jobs:
         echo "ubuntu_matrix=$matrix_targets" >> $GITHUB_OUTPUT
         echo "Generated matrix: $matrix_targets"
 
-        # Targets with qualification hardware, mapped to the self-hosted runner
-        # group that owns each. The qualify job runs one leg per selected target
-        # that appears here; targets absent from this registry build and release
-        # exactly as before (qualify skips them -> release ungated, unchanged).
-        # Adding a runner for a new target (e.g. a CDNA box for gfx942) is a
-        # one-line addition to this map.
-        QUALIFIED_RUNNERS='{"gfx1151":"dev_lab"}'
+        # Targets with qualification hardware, mapped to the runs-on labels that
+        # reach it. The qualify job runs one leg per selected target that appears
+        # here; targets absent from this registry build and release exactly as
+        # before (qualify skips them -> release ungated, unchanged). Adding a
+        # runner for a new target (e.g. a CDNA box for gfx942) is a one-line
+        # addition to this map.
+        #
+        # Was '{"gfx1151":"dev_lab"}', naming a runner group. It names labels
+        # now: gfx1151 is Strix Halo, and the DevLab ephemeral pool answers to
+        # `devlab-dispatch` + `strix-halo`. See vllm-rocm#42.
+        QUALIFIED_RUNNERS='{"gfx1151":["self-hosted","Linux","devlab-dispatch","strix-halo"]}'
         qualify_matrix=$(echo "$targets" \
           | tr ',' '\n' \
           | sed 's/^ *//;s/ *$//' \
           | jq -R . \
           | jq -s --argjson q "$QUALIFIED_RUNNERS" \
-              'unique | {include: [.[] | select($q[.] != null) | {gfx: ., runner_group: $q[.]}]}' \
+              'unique | {include: [.[] | select($q[.] != null) | {gfx: ., runner_labels: $q[.]}]}' \
           | jq -c)
         # JSON array (not a comma list): consumers use fromJson() set membership,
         # so no target string can substring-match another.
@@ -216,19 +220,28 @@ jobs:
         echo "Qualify matrix: $qualify_matrix"
 
   build-ubuntu:
-    # Target the dev_lab runner GROUP explicitly, not just labels. The org's
-    # Default group is visibility:all, so a bare [self-hosted, Linux] also
-    # matches Linux boxes in other groups (stx / sjlab / Default) the repo can
-    # see — runs landed on a non-dev_lab box. `group: dev_lab` + the Linux label
-    # selects only the dev_lab Linux box (currently ta-devlab-halo-03) with no
-    # name-pin, so it survives re-image/rename as long as the box stays in the
-    # group. AMD's frameworks-nightlies host allowlists these boxes' egress but
-    # 403s GitHub-hosted runner IPs, so the nightly vLLM wheel must be fetched
-    # here. Build needs only network + pip (no GPU); it shares the box with
-    # qualify, which runs after via `needs`.
-    runs-on:
-      group: dev_lab
-      labels: [self-hosted, Linux]
+    # Moved from the dev_lab runner GROUP to AMD DevLab's ephemeral pool.
+    #
+    # The group was here to solve a targeting problem: the org's Default group
+    # is visibility:all, so a bare [self-hosted, Linux] also matched Linux boxes
+    # in other groups (stx / sjlab / Default) and runs landed on a non-dev_lab
+    # box. `devlab-dispatch` solves the same problem by label instead -- only
+    # the ephemeral pool's hosts carry it, and it exists precisely so that
+    # reaching this pool is something a workflow opts into rather than something
+    # a generic [self-hosted, Linux] falls into. `strix-halo` then narrows to
+    # Halo silicon.
+    #
+    # WATCH THIS ONE: AMD's frameworks-nightlies host allowlists the dev_lab
+    # boxes' egress and 403s GitHub-hosted runner IPs, which is why the nightly
+    # vLLM wheel has to be fetched on a lab box at all. Whether the ephemeral
+    # pool's Halos are inside that allowlist is the open question this change
+    # answers -- if the wheel fetch 403s here, this job is the reason to revert.
+    # See lemonade-sdk/vllm-rocm#42.
+    #
+    # Build needs only network + pip (no GPU). It no longer shares a box with
+    # qualify -- each ephemeral leg gets its own host -- which is fine, since
+    # they already pass artifacts rather than filesystem state.
+    runs-on: [self-hosted, Linux, devlab-dispatch, strix-halo]
     needs: [prepare-matrix, detect-nightly]
     # Skip the whole build (and everything downstream — qualify/create-release
     # cascade off a skipped build) when this build has already been qualified.
@@ -940,9 +953,11 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.qualify_matrix) }}
       fail-fast: false
-    runs-on:
-      group: ${{ matrix.runner_group }}
-      labels: [self-hosted, Linux]
+    # Moved to the ephemeral pool alongside build-ubuntu. `matrix.runner_labels`
+    # rather than a group, for the reasons in build-ubuntu above; the registry
+    # in prepare-matrix still decides *which* targets qualify, it just names
+    # labels now instead of a runner group.
+    runs-on: ${{ matrix.runner_labels }}
     env:
       GFX: ${{ matrix.gfx }}
     # Runs on release builds AND on omni dispatches (omni is experimental —


### PR DESCRIPTION
Refs #42, which asked whether `build-ubuntu` can move to the ephemeral pool or whether the nightlies egress allowlist pins it to `ta-devlab-halo-03`. This PR answers it by running it.

## What changed

| Job | Was | Now |
|---|---|---|
| `build-ubuntu` | `group: dev_lab` + `[self-hosted, Linux]` | `[self-hosted, Linux, devlab-dispatch, strix-halo]` |
| `qualify` | `group: ${{ matrix.runner_group }}` + `[self-hosted, Linux]` | `${{ matrix.runner_labels }}` |
| `prepare-matrix` | `QUALIFIED_RUNNERS='{"gfx1151":"dev_lab"}'` | `'{"gfx1151":["self-hosted","Linux","devlab-dispatch","strix-halo"]}'` |

The runner group was solving a real targeting problem, and the replacement solves the same one the same way. The org's Default group is `visibility:all`, so a bare `[self-hosted, Linux]` also matched boxes in `stx` / `sjlab` / `Default` and runs landed off `dev_lab`. `devlab-dispatch` is carried only by the ephemeral pool's hosts and exists precisely so that reaching the pool is opt-in rather than somewhere a generic `[self-hosted, Linux]` falls into. `strix-halo` then narrows to Halo silicon, which is what gfx1151 is.

`QUALIFIED_RUNNERS` still decides *which* targets qualify — it names labels instead of a group now. Downstream consumers read `.include[].gfx`, so `qualify_targets` and `qualify_count` are unchanged, and targets absent from the registry still skip qualification and release ungated exactly as before.

## The thing to watch

The comment on `build-ubuntu` says AMD's frameworks-nightlies host allowlists the dev_lab boxes' egress and 403s GitHub-hosted runner IPs, which is why the nightly wheel is fetched on a lab box at all. **Whether the ephemeral Halos sit inside that allowlist is not something this diff can assert.** It is what the PR run is for. A 403 on the wheel fetch is the signal to revert `build-ubuntu` specifically — `qualify` would be unaffected, since it consumes an artifact rather than the network.

I have left the warning in the file rather than deleting it with the group, because it stays true whichever way this lands.

## Second-order change

`build-ubuntu` no longer shares a host with `qualify` — each ephemeral leg gets its own machine, provisioned for the job and destroyed after. They already hand off via artifacts rather than filesystem state, so this should be invisible; flagging it because the old comment called out the sharing explicitly.

---

## Run results

**[33901787822](https://github.com/lemonade-sdk/vllm-rocm/actions/runs/33901787822)** — `workflow_dispatch` on this branch, `channel=nightly gfx_target=gfx1151 force=true create_release=false`.

### `build-ubuntu`: success on the ephemeral pool

```
build-ubuntu (gfx1151)  success  runner=ephemeral-devlab-x2-la01-s01-d06-101117377032
```

**The egress question in #42 is answered: the wheel fetch works from the ephemeral pool.** The job resolved and pulled from the allowlisted hosts with no 403:

```
Using PyTorch index: https://repo.amd.com/rocm/whl/gfx1151/
Using vLLM index:    https://rocm.frameworks.amd.com/whl/gfx1151/

Successfully installed ... torch-2.12.0+rocm7.15.0a20260724
                           triton-3.8.0+git4cff872c.rocm7.15.0a20260724
                           rocm-sdk-device-gfx1151-7.15.0a20260724 ...
```

Bundle built, shebangs made relocatable (`0 absolute python shebangs remain; 99 rewritten scripts compile`), and `Native extensions verified`. So the concern the old comment recorded — that only the dev_lab boxes are inside the nightlies allowlist — does not extend to the DevLab ephemeral Halos. I have left the warning in the file anyway, since it stays true about GitHub-hosted runners.

### `qualify`: not exercised, and not for a reason to do with this change

It skipped because I dispatched with `create_release=false` to avoid publishing a release from an unmerged branch, and `qualify`'s `if:` requires `create_release` to be true/null (or `omni`). My own guard suppressed it.

What *is* verified is the part this PR changed — `prepare-matrix` emitted the new shape correctly:

```
Qualify matrix: {"include":[{"gfx":"gfx1151",
                 "runner_labels":["self-hosted","Linux","devlab-dispatch","strix-halo"]}]}
```

`qualify_count=1`, unchanged, so the job would have been created and would have targeted the pool. It has simply not had a green run yet. I did not force one, because the only dispatch combinations that enable `qualify` also enable `create-release`, which has no branch guard and would publish a release from this branch. Happy to run it if you would rather see it, or it will exercise itself on the first scheduled run after merge.

### The earlier PR-event run

[33901717834](https://github.com/lemonade-sdk/vllm-rocm/actions/runs/33901717834) is green, but it proves nothing: `build-ubuntu` was skipped by the nightly dedup, so no self-hosted leg ran. Flagging it so the green check is not read as evidence.